### PR TITLE
fix(gemini): only pass --skip-trust when the installed CLI supports it

### DIFF
--- a/scripts/providers/gemini-cli.sh
+++ b/scripts/providers/gemini-cli.sh
@@ -30,8 +30,14 @@ ${PROMPT}"
 # --skip-trust bypasses the trusted-folders guardrail for non-interactive use.
 # The council only sends text and reads text; gemini gets no filesystem access
 # from us, so the guardrail is overcautious for this code path.
+# Gemini CLI >= 0.37 removed --skip-trust; only pass it when the installed
+# binary still advertises it, otherwise headless -p mode aborts with an
+# "Unknown argument: skip-trust" error and the provider fails for every query.
 MODEL=$(get_model gemini-cli)
-ARGS=(--skip-trust -m "$MODEL" -p "$FULL_PROMPT")
+ARGS=(-m "$MODEL" -p "$FULL_PROMPT")
+if gemini --help 2>&1 | grep -q -- '--skip-trust'; then
+    ARGS=(--skip-trust "${ARGS[@]}")
+fi
 
 ERR_TMP=$(mktemp)
 trap 'rm -f "$ERR_TMP"' EXIT


### PR DESCRIPTION
## Problem

Gemini CLI **>= 0.37 removed the `--skip-trust` flag**. The `gemini-cli` provider passes it unconditionally:

```bash
ARGS=(--skip-trust -m "$MODEL" -p "$FULL_PROMPT")
```

On any recent Gemini CLI this makes **every** council query fail, because `gemini` aborts before answering:

```
Unknown argument: skip-trust
```

So `/council ask` returns an error from the gemini provider for all users who are on a current CLI.

## Fix

Pass `--skip-trust` only when the installed binary still advertises it:

```bash
MODEL=$(get_model gemini-cli)
ARGS=(-m "$MODEL" -p "$FULL_PROMPT")
if gemini --help 2>&1 | grep -q -- '--skip-trust'; then
    ARGS=(--skip-trust "${ARGS[@]}")
fi
```

- **Older CLIs (< 0.37):** flag still detected and passed. Behaviour unchanged.
- **Newer CLIs (>= 0.37):** flag omitted. Headless `-p` mode runs fine without it. The trusted-folders guardrail does not apply to this code path anyway, since the council only sends and reads text and gives gemini no filesystem access.

## Verification

- `gemini --version` -> `0.37.1`, `gemini --help` no longer lists `--skip-trust` (confirmed)
- With the fix, the gemini-cli provider succeeds again on 0.37.1
- `bash -n scripts/providers/gemini-cli.sh` passes
- Backward compatible: pre-0.37 CLIs that still expose the flag keep getting it

🤖 Generated with [Claude Code](https://claude.com/claude-code)