### PR TITLE
fix: pass large blobs to jq via files/stdin, not argv (MSYS ARG_MAX overflow)

### DIFF
--- a/scripts/query-council.sh
+++ b/scripts/query-council.sh
@@ -298,8 +298,8 @@ attempt_api_fallback() {
             return 0
         fi
     fi
-    jq -n --arg r "$resp" --arg m "$sibling_model" --arg s "$sibling" \
-        '{response: $r, model: $m, fallback: $s}'
+    printf '%s' "$resp" | jq -Rs --arg m "$sibling_model" --arg s "$sibling" \
+        '{response: ., model: $m, fallback: $s}'
 }
 
 # Compose a success slot from an attempt_api_fallback object ({response, model,
@@ -330,8 +330,8 @@ finish_with_fallback_or_error() {
         return 0
     fi
     # No fallback available, or it failed too: preserve the original error.
-    jq -n --arg e "$error_msg" --arg role "$role" \
-        '{status: "error", error: $e, cached: false, role: (if $role == "" then null else $role end)}' > "$output_file"
+    printf '%s' "$error_msg" | jq -Rs --arg role "$role" \
+        '{status: "error", error: ., cached: false, role: (if $role == "" then null else $role end)}' > "$output_file"
     if [[ -n "${COUNCIL_PANE_DIR:-}" ]]; then
         pane_error_write "$COUNCIL_PANE_DIR" "$provider" "$error_msg"
         pane_status_event "$COUNCIL_PANE_DIR" "$provider" error "" "$(get_model "$provider")"
@@ -378,8 +378,8 @@ query_provider() {
         local cached_response
         cached_response=$(cache_get "$key")
         if [[ -n "$cached_response" ]]; then
-            jq -n --arg r "$cached_response" --arg role "$role" \
-                '{status: "success", response: $r, cached: true, role: (if $role == "" then null else $role end)}' > "$output_file"
+            printf '%s' "$cached_response" | jq -Rs --arg role "$role" \
+                '{status: "success", response: ., cached: true, role: (if $role == "" then null else $role end)}' > "$output_file"
             if [[ -n "${COUNCIL_PANE_DIR:-}" ]]; then
                 pane_status_event "$COUNCIL_PANE_DIR" "$provider" cached "" "$model"
                 pane_response_write "$COUNCIL_PANE_DIR" "$provider" "$cached_response"
@@ -391,8 +391,8 @@ query_provider() {
     # Query provider with role-injected prompt
     if response=$("$script" "$final_prompt" 2>&1); then
         local elapsed=$(( $(now_ms) - start_ms ))
-        jq -n --arg r "$response" --arg role "$role" \
-            '{status: "success", response: $r, cached: false, role: (if $role == "" then null else $role end)}' > "$output_file"
+        printf '%s' "$response" | jq -Rs --arg role "$role" \
+            '{status: "success", response: ., cached: false, role: (if $role == "" then null else $role end)}' > "$output_file"
         if [[ -n "${COUNCIL_PANE_DIR:-}" ]]; then
             pane_status_event "$COUNCIL_PANE_DIR" "$provider" complete "$elapsed" "$model"
             pane_response_write "$COUNCIL_PANE_DIR" "$provider" "$response"
@@ -511,7 +511,9 @@ for provider in "${PROVIDERS[@]}"; do
         # coerce_result_json adds the model and guarantees valid JSON, so a
         # provider that wrote malformed output can't crash the whole run here.
         result=$(coerce_result_json "$(cat "$result_file")" "$model")
-        RESULTS=$(echo "$RESULTS" | jq --arg p "$provider" --argjson r "$result" '.[$p] = $r')
+        _accf=$(mktemp); printf '%s' "$result" > "$_accf"
+        RESULTS=$(printf '%s' "$RESULTS" | jq --arg p "$provider" --slurpfile r "$_accf" '.[$p] = $r[0]')
+        rm -f "$_accf"
 
         # Show the model that actually answered: on a fallback the slot carries
         # the API sibling's model, not this provider's CLI default. coerce_result_json
@@ -579,13 +581,13 @@ if [[ "$DEBATE_MODE" == true ]]; then
             if [[ ! -x "$script" ]]; then
                 echo '{"status": "error", "error": "Script not found"}' > "$output_file"
             elif response=$("$script" "$debate_prompt" 2>&1); then
-                jq -n --arg r "$response" '{status: "success", response: $r}' > "$output_file"
+                printf '%s' "$response" | jq -Rs '{status: "success", response: .}' > "$output_file"
             else
                 fb_json=$(attempt_api_fallback "$provider" "$debate_prompt")
                 if [[ -n "$fb_json" ]]; then
                     fallback_slot_json "$fb_json" "" > "$output_file"
                 else
-                    jq -n --arg e "$response" '{status: "error", error: $e}' > "$output_file"
+                    printf '%s' "$response" | jq -Rs '{status: "error", error: .}' > "$output_file"
                 fi
             fi
         ) &
@@ -605,7 +607,9 @@ if [[ "$DEBATE_MODE" == true ]]; then
 
         if [[ -f "$result_file" ]]; then
             result=$(coerce_result_json "$(cat "$result_file")" "$model")
-            ROUND2_RESULTS=$(echo "$ROUND2_RESULTS" | jq --arg p "$provider" --argjson r "$result" '.[$p] = $r')
+            _accf=$(mktemp); printf '%s' "$result" > "$_accf"
+            ROUND2_RESULTS=$(printf '%s' "$ROUND2_RESULTS" | jq --arg p "$provider" --slurpfile r "$_accf" '.[$p] = $r[0]')
+            rm -f "$_accf"
 
             status=$(echo "$result" | jq -r '.status')
             if [[ "$status" == "error" ]]; then
@@ -628,8 +632,9 @@ if [[ -n "$ROLES" ]]; then
 else
     ROLES_JSON="null"
 fi
+_prompt_f=$(mktemp); printf '%s' "$PROMPT" > "$_prompt_f"   # prompt+auto-context can exceed argv limit
 METADATA=$(jq -n \
-    --arg prompt "$PROMPT" \
+    --rawfile prompt "$_prompt_f" \
     --arg file_path "$FILE_PATH" \
     --argjson roles_used "$ROLES_JSON" \
     --argjson debate_mode "$DEBATE_MODE" \
@@ -647,20 +652,32 @@ METADATA=$(jq -n \
         auto_context: $auto_context,
         timestamp: $timestamp
     }')
+rm -f "$_prompt_f"
 
-# Output final JSON with metadata and results
+# Output final JSON with metadata and results.
+# Pass large blobs (metadata + all provider responses) via TEMP FILES with
+# --slurpfile, NOT command-line --argjson: on MSYS/Windows ARG_MAX is small
+# (~32KB) and the combined responses overflow it, producing
+# "jq: Argument list too long" and silently dropping every response.
+_meta_f=$(mktemp); _r1_f=$(mktemp)
+printf '%s' "$METADATA" > "$_meta_f"
+printf '%s' "$RESULTS" > "$_r1_f"
 if [[ "$DEBATE_MODE" == true ]]; then
+    _r2_f=$(mktemp)
+    printf '%s' "$ROUND2_RESULTS" > "$_r2_f"
     jq -n \
-        --argjson metadata "$METADATA" \
-        --argjson round1 "$RESULTS" \
-        --argjson round2 "$ROUND2_RESULTS" \
-        '{metadata: $metadata, round1: $round1, round2: $round2}'
+        --slurpfile metadata "$_meta_f" \
+        --slurpfile round1 "$_r1_f" \
+        --slurpfile round2 "$_r2_f" \
+        '{metadata: $metadata[0], round1: $round1[0], round2: $round2[0]}'
+    rm -f "$_r2_f"
 else
     jq -n \
-        --argjson metadata "$METADATA" \
-        --argjson round1 "$RESULTS" \
-        '{metadata: $metadata, round1: $round1}'
+        --slurpfile metadata "$_meta_f" \
+        --slurpfile round1 "$_r1_f" \
+        '{metadata: $metadata[0], round1: $round1[0]}'
 fi
+rm -f "$_meta_f" "$_r1_f"
 
 # Report errors to stderr
 if [[ ${#ERRORS[@]} -gt 0 ]]; then


### PR DESCRIPTION
## Problem

On Windows/MSYS, `ARG_MAX` is ~32 KB. `query-council.sh` builds its output by passing the combined provider responses (plus the metadata prompt, per-provider captures, and the round accumulators) to `jq` via command-line `--arg`/`--argjson`. At `standard`/`detailed` verbosity the combined responses exceed ~32 KB, so the **final output build dies with `jq: Argument list too long`** and the script silently emits nothing — every provider response is lost on Windows. (Linux's `ARG_MAX` is ~2 MB, so it's unaffected.)

## Fix

Make the whole class arg-safe (a no-op on Linux):

- final output + per-provider round accumulators → temp file + `--slurpfile`
- per-provider response / error / sibling-fallback captures → pipe via stdin + `jq -Rs`
- metadata prompt (can be large with auto-context) → temp file + `--rawfile`

`printf` is a bash builtin, so piping a large string into `jq -Rs` is not subject to `ARG_MAX`; the temp-file `--slurpfile`/`--rawfile` paths cover the JSON/aggregate cases.

## Verification

- Repro: the old `--argjson` path overflows at a 49 KB payload (`jq` exit 126, `Argument list too long`).
- Fixed: the new path returns valid JSON with full response text intact; an end-to-end query through the patched pipeline rendered every provider's response with no overflow.
- `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
