### PR TITLE
fix(check-status): reclassify xAI 400+invalid-argument as auth error

### DIFF
--- a/scripts/check-status.sh
+++ b/scripts/check-status.sh
@@ -61,11 +61,22 @@ check_provider() {
             rm -f "$cfg"
             ;;
         grok)
+            # xAI returns 400 with {"code":"invalid-argument",...} for a bad
+            # key instead of the standard 401. Capture the body so we can
+            # reclassify that specific 400 as an auth failure (all other 400s
+            # still fall through to the generic error path).
             cfg=$(curl_secret_config "Authorization: Bearer ${api_key}")
-            http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+            local response
+            response=$(curl -s -w $'\n%{http_code}' --max-time 10 \
                 --config "$cfg" \
-                "https://api.x.ai/v1/models" 2>/dev/null || echo "000")
+                "https://api.x.ai/v1/models" 2>/dev/null || printf '\n000')
             rm -f "$cfg"
+            http_code=$(printf '%s' "$response" | tail -n1)
+            if [[ "$http_code" == "400" ]] \
+                && [[ "$(printf '%s' "$response" | sed '$d')" == *'"code":"invalid-argument"'* ]]; then
+                echo "auth_error:400"
+                return
+            fi
             ;;
         perplexity)
             # Perplexity has no /models endpoint, so auth can only be probed with


### PR DESCRIPTION
## Summary

`check-status.sh`'s Grok probe reports `Error (HTTP 400)` with no fix hint when the xAI API key is rejected, because xAI returns HTTP **400** with `{"code":"invalid-argument","error":"Incorrect API key provided..."}` for a bad key instead of the standard **401**. That drops the response into the generic `error:${http_code}` bucket, past the `401|403 → auth_error` branch that normally triggers the `key rejected - regenerate it` remediation hint.

This PR captures the response body alongside the status code in the `grok)` case and reclassifies that specific shape as `auth_error:400`. The existing `auth_error:*` formatter then renders it as `Auth failed (HTTP 400)` with the regenerate-key fix hint — preserving the real HTTP code in the display so future debugging isn't misleading.

## Reproduction

Set `XAI_API_KEY` to a revoked/invalid xAI key and run `bash scripts/check-status.sh`.

**Before:**
```
🟥 Grok    x Error (HTTP 400)
```

**After:**
```
🟥 Grok    x Auth failed (HTTP 400)  fix: key rejected - regenerate it
```

The observed body from xAI:
```json
{"code":"invalid-argument","error":"Incorrect API key provided. You can obtain an API key from https://console.x.ai."}
```

## Scope

- **Only** the `grok)` case in `check_provider` is touched. Other providers keep their status-code-only classification, and Grok's remaining 400s (malformed request, etc.) still fall through to the generic `error:400` path since they won't carry `code:invalid-argument`.
- The `curl_secret_config` / `--config "$cfg"` hardening pattern is preserved.
- No changes to public interfaces; `check_provider` still emits the same string vocabulary (`ok:*`, `timeout`, `auth_error:*`, `error:*`, `no_key`).

## Test plan

- [x] `bash -n scripts/check-status.sh` — syntax OK.
- [x] Ran the equivalent patch against a real (invalid) xAI key locally and verified the listing renders `Auth failed (HTTP 400)  fix: key rejected - regenerate it`.
- [ ] Existing `tests/check-status.bats` scope is keyless-only (per its ABOUTME comment), so no in-suite regression is expected. I did not add an HTTP-response-body test since it would require introducing a curl stub — happy to add one if you'd prefer.

## Notes

- No CHANGELOG entry included since the changelog is version-cut on release; slot the entry wherever fits the next `YYYY.M.BUILD`.