### PR TITLE
Fix /status misreporting rejected keys, timeouts, and its own Perplexity probe

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -53,7 +53,7 @@ bats --verbose-run tests/cache.bats
 | `format-output.bats` | 11 tests | defensive parsing: empty/missing/non-string responses, raw preservation, fallback-note rendering |
 | `prompts.bats` | 11 tests | template loading, {{VAR}} interpolation, role-injection rendering |
 | `agent-analysis.bats` | 11 tests | validate-analysis.sh contract enforcement, schema sync |
-| `check-status.bats` | 12 tests | two-tier CLI availability, remediation strings, HTTP probe branches, keys off the curl argv, ms clock |
+| `check-status.bats` | 16 tests | two-tier CLI availability, remediation strings, HTTP probe branches, rejected-key classification (Gemini/xAI answer a bad key with 400, not 401), transfer-failure exit codes, Perplexity's minimum max_tokens, keys off the curl argv, ms clock |
 | `jobs.bats` | 16 tests | job store, --async lifecycle, --result/--jobs/--cancel, self-ignoring cache dir |
 | `stop-gate.bats` | 10 tests | opt-in gating, loop guards, BLOCK verdict, fail-open |
 | `theme.bats` | 24 tests | terminal theme detection, theme-aware emphasis + muted-text (faint/gray) rendering |
@@ -64,7 +64,7 @@ bats --verbose-run tests/cache.bats
 | `release.bats` | 5 tests | release.sh version bump/commit/tag, staged-index guard, green-suite gate |
 | `retry.bats` | 6 tests | curl_with_retry backoff + status handling, curl_secret_config off-argv config file |
 
-**Total: 354 tests** across 23 `.bats` files.
+**Total: 358 tests** across 23 `.bats` files.
 
 ### Hermetic CLI Fixture
 

--- a/scripts/check-status.sh
+++ b/scripts/check-status.sh
@@ -26,6 +26,19 @@ now_ms() {
 
 # Check a single provider
 # Usage: check_provider <name> <api_key_var> <model_var> <default_model> <test_endpoint> <test_payload>
+# Vendors disagree on how a rejected key comes back. OpenAI and Perplexity send
+# 401, but Gemini sends 400 with status INVALID_ARGUMENT and xAI sends 400 with
+# code invalid-argument. For those two the response body, not the status alone,
+# separates a rejected key from a genuinely malformed request.
+rejected_key() {
+    local provider="$1" body_file="$2"
+    case "$provider" in
+        gemini) jq -e '.error.status == "INVALID_ARGUMENT"' "$body_file" >/dev/null 2>&1 ;;
+        grok)   jq -e '.code == "invalid-argument"' "$body_file" >/dev/null 2>&1 ;;
+        *)      return 1 ;;
+    esac
+}
+
 check_provider() {
     local name="$1"
     local api_key="${!2:-}"
@@ -44,39 +57,43 @@ check_provider() {
 
     # Keys travel via a mode-600 curl --config file, never the argv (ps-visible)
     # or the URL. Mirrors the provider scripts' curl_secret_config hardening.
-    local http_code cfg
+    # The response body is kept because some vendors only reveal a rejected key
+    # there. It can carry a redacted copy of the key, so it stays in its
+    # mode-600 temp file: inspected, never printed, and removed straight after.
+    local http_code cfg body_file rejected
+    body_file=$(mktemp)
     case "$name" in
         gemini)
             cfg=$(curl_secret_config "x-goog-api-key: ${api_key}")
-            http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+            http_code=$(curl -s -o "$body_file" -w "%{http_code}" --max-time 10 \
                 --config "$cfg" \
                 "https://generativelanguage.googleapis.com/v1beta/models/${model}" 2>/dev/null || true)
             rm -f "$cfg"
             ;;
         openai)
             cfg=$(curl_secret_config "Authorization: Bearer ${api_key}")
-            http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+            http_code=$(curl -s -o "$body_file" -w "%{http_code}" --max-time 10 \
                 --config "$cfg" \
                 "https://api.openai.com/v1/models" 2>/dev/null || true)
             rm -f "$cfg"
             ;;
         grok)
             cfg=$(curl_secret_config "Authorization: Bearer ${api_key}")
-            http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+            http_code=$(curl -s -o "$body_file" -w "%{http_code}" --max-time 10 \
                 --config "$cfg" \
                 "https://api.x.ai/v1/models" 2>/dev/null || true)
             rm -f "$cfg"
             ;;
         perplexity)
             # Perplexity has no /models endpoint, so auth can only be probed with
-            # a (billable) chat request. Cap it at max_tokens:1 to make the status
-            # check as close to free as the API allows.
+            # a (billable) chat request. The API rejects anything under 16 output
+            # tokens, so 16 is as close to free as the status check can get.
             cfg=$(curl_secret_config "Authorization: Bearer ${api_key}")
-            http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+            http_code=$(curl -s -o "$body_file" -w "%{http_code}" --max-time 10 \
                 -X POST \
                 --config "$cfg" \
                 -H "Content-Type: application/json" \
-                -d '{"model":"sonar","messages":[{"role":"user","content":"hi"}],"max_tokens":1}' \
+                -d '{"model":"sonar","messages":[{"role":"user","content":"hi"}],"max_tokens":16}' \
                 "https://api.perplexity.ai/chat/completions" 2>/dev/null || true)
             rm -f "$cfg"
             ;;
@@ -86,6 +103,17 @@ check_provider() {
     # The `|| true` above absorbs that exit for set -e without appending a
     # second 000 to the code. An empty code means curl wrote nothing at all.
     http_code="${http_code:-000}"
+
+    rejected=0
+    if [[ "$http_code" == "400" ]] && rejected_key "$name" "$body_file"; then
+        rejected=1
+    fi
+    rm -f "$body_file"
+    if (( rejected )); then
+        # Report the auth failure under the vendor's true code, not an invented 401
+        echo "auth_error:400"
+        return
+    fi
 
     end_time=$(now_ms)
 

--- a/scripts/check-status.sh
+++ b/scripts/check-status.sh
@@ -50,21 +50,21 @@ check_provider() {
             cfg=$(curl_secret_config "x-goog-api-key: ${api_key}")
             http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
                 --config "$cfg" \
-                "https://generativelanguage.googleapis.com/v1beta/models/${model}" 2>/dev/null || echo "000")
+                "https://generativelanguage.googleapis.com/v1beta/models/${model}" 2>/dev/null || true)
             rm -f "$cfg"
             ;;
         openai)
             cfg=$(curl_secret_config "Authorization: Bearer ${api_key}")
             http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
                 --config "$cfg" \
-                "https://api.openai.com/v1/models" 2>/dev/null || echo "000")
+                "https://api.openai.com/v1/models" 2>/dev/null || true)
             rm -f "$cfg"
             ;;
         grok)
             cfg=$(curl_secret_config "Authorization: Bearer ${api_key}")
             http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
                 --config "$cfg" \
-                "https://api.x.ai/v1/models" 2>/dev/null || echo "000")
+                "https://api.x.ai/v1/models" 2>/dev/null || true)
             rm -f "$cfg"
             ;;
         perplexity)
@@ -77,10 +77,15 @@ check_provider() {
                 --config "$cfg" \
                 -H "Content-Type: application/json" \
                 -d '{"model":"sonar","messages":[{"role":"user","content":"hi"}],"max_tokens":1}' \
-                "https://api.perplexity.ai/chat/completions" 2>/dev/null || echo "000")
+                "https://api.perplexity.ai/chat/completions" 2>/dev/null || true)
             rm -f "$cfg"
             ;;
     esac
+
+    # On a failed transfer curl writes 000 through -w and also exits non-zero.
+    # The `|| true` above absorbs that exit for set -e without appending a
+    # second 000 to the code. An empty code means curl wrote nothing at all.
+    http_code="${http_code:-000}"
 
     end_time=$(now_ms)
 

--- a/tests/check-status.bats
+++ b/tests/check-status.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 # ABOUTME: Tests for check-status.sh two-tier availability and remediation output
-# ABOUTME: Hermetic via fake CLIs; API providers exercised only in keyless states
+# ABOUTME: Hermetic via fake CLIs and a shadow curl; no real keys or network
 
 load test_helper
 load fixtures/fake-clis
@@ -64,12 +64,20 @@ setup() {
 # Shadow curl with a stub that echoes a scripted HTTP code, so check_provider's
 # result branches can be exercised offline with no real keys or network. Keys
 # are dummy values only to get past the no_key guard.
+#
+# The stub exits non-zero on a failed transfer (code 000) because that is what
+# the real binary does: curl writes 000 through -w and *also* exits 7. A stub
+# that always succeeds cannot exercise the script's transfer-failure branch, so
+# it would certify that branch as working while it is broken.
 shadow_curl() {
     local dir="${BATS_TEST_TMPDIR}/fakecurl"
     mkdir -p "$dir"
     cat > "$dir/curl" <<'EOF'
 #!/bin/bash
-printf '%s' "${COUNCIL_FAKE_HTTP_CODE:-200}"
+code="${COUNCIL_FAKE_HTTP_CODE:-200}"
+printf '%s' "$code"
+if [[ "$code" == "000" ]]; then exit 7; fi
+exit 0
 EOF
     chmod +x "$dir/curl"
     export PATH="$dir:$PATH"

--- a/tests/check-status.bats
+++ b/tests/check-status.bats
@@ -75,6 +75,15 @@ shadow_curl() {
     cat > "$dir/curl" <<'EOF'
 #!/bin/bash
 code="${COUNCIL_FAKE_HTTP_CODE:-200}"
+# Mirror curl's -o: the body lands in the named file, never on stdout, so a
+# probe that inspects the body reads it exactly as it would from the real thing.
+out=""
+prev=""
+for arg in "$@"; do
+    if [[ "$prev" == "-o" ]]; then out="$arg"; fi
+    prev="$arg"
+done
+if [[ -n "$out" ]]; then printf '%s' "${COUNCIL_FAKE_HTTP_BODY:-}" > "$out"; fi
 printf '%s' "$code"
 if [[ "$code" == "000" ]]; then exit 7; fi
 exit 0
@@ -124,6 +133,56 @@ EOF
     [[ "$output" == *"2/6 providers available"* ]]
 }
 
+# Gemini and xAI answer a rejected key with 400 rather than the 401 OpenAI and
+# Perplexity send, so the status code alone cannot classify it and each vendor
+# marks it differently in the body. Both bodies below are verbatim responses
+# captured from the live APIs for a bad key. Each test also asserts that exactly
+# one provider is flagged, which proves one vendor's shape cannot match another's.
+
+# Count the providers reported as an auth failure (one row per provider).
+auth_failures() {
+    printf '%s\n' "$1" | grep -c 'Auth failed' || true
+}
+
+@test "check-status: xAI 400 with an invalid-argument body reports auth failure" {
+    shadow_curl
+    export COUNCIL_FAKE_HTTP_CODE=400
+    export COUNCIL_FAKE_HTTP_BODY='{"code":"invalid-argument","error":"Incorrect API key provided. You can obtain an API key from https://console.x.ai."}'
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    # Reported as an auth failure, but keeping the true code so debugging is honest
+    [[ "$output" == *"Auth failed (HTTP 400)"* ]]
+    [[ "$output" == *"key rejected - regenerate it"* ]]
+    # Only Grok matches this shape; the other three 400s stay generic errors
+    [ "$(auth_failures "$output")" -eq 1 ]
+    [[ "$output" == *"Error (HTTP 400)"* ]]
+}
+
+@test "check-status: Gemini 400 with an INVALID_ARGUMENT body reports auth failure" {
+    shadow_curl
+    export COUNCIL_FAKE_HTTP_CODE=400
+    export COUNCIL_FAKE_HTTP_BODY='{"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT"}}'
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Auth failed (HTTP 400)"* ]]
+    [[ "$output" == *"key rejected - regenerate it"* ]]
+    # Only Gemini matches this shape; the other three 400s stay generic errors
+    [ "$(auth_failures "$output")" -eq 1 ]
+    [[ "$output" == *"Error (HTTP 400)"* ]]
+}
+
+@test "check-status: a 400 that no vendor marks as a bad key stays a generic error" {
+    shadow_curl
+    export COUNCIL_FAKE_HTTP_CODE=400
+    export COUNCIL_FAKE_HTTP_BODY='{"code":"failed-precondition","error":"malformed request"}'
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    # A malformed request is not a credentials problem; do not offer to regenerate
+    [[ "$output" == *"Error (HTTP 400)"* ]]
+    [ "$(auth_failures "$output")" -eq 0 ]
+    [[ "$output" != *"key rejected"* ]]
+}
+
 # ---- secret hygiene: /status probes must keep keys off the process argv ----
 
 # Recording curl: appends its argv (one arg per line) to CS_ARGV_FILE, copies any
@@ -149,6 +208,22 @@ EOF
     export GEMINI_API_KEY=SEKRET_GEM OPENAI_API_KEY=SEKRET_OAI \
            XAI_API_KEY=SEKRET_GROK PERPLEXITY_API_KEY=SEKRET_PPX
     export COUNCIL_FAKE_BEHAVIOR=valid
+}
+
+# Perplexity is the one provider probed with a chat request, and it rejects any
+# request below 16 output tokens with HTTP 400 ("max_tokens must be at least
+# 16"). A probe cheaper than the floor is not a cheaper probe, it is a broken
+# one, and the stubbed curl above cannot notice: only the payload we send can.
+@test "check-status: the Perplexity probe requests at least the API's minimum max_tokens" {
+    record_curl
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ -s "$CS_ARGV_FILE" ]
+    local payload max_tokens
+    payload=$(grep -o '{"model":"sonar".*}' "$CS_ARGV_FILE" | head -1)
+    [ -n "$payload" ]
+    max_tokens=$(printf '%s' "$payload" | jq -r '.max_tokens')
+    [ "$max_tokens" -ge 16 ]
 }
 
 @test "check-status: probe API keys never appear on the curl argv" {


### PR DESCRIPTION
Supersedes #6, which correctly diagnosed the xAI half of this. Verifying that PR
turned up two more bugs in the same function, so this generalizes the fix and
adds the regression tests. **Credit for the diagnosis and the original fix goes
to @kromah** (co-authored on the commit).

## 1. A rejected key is not always a 401

Probed each vendor with a deliberately invalid key:

| Provider | Bad-key status | Body signature | Before |
|---|---|---|---|
| Gemini | **400** | `.error.status == "INVALID_ARGUMENT"` | `Error (HTTP 400)`, no hint |
| Grok | **400** | `.code == "invalid-argument"` | `Error (HTTP 400)`, no hint |
| OpenAI | 401 | — | correct |
| Perplexity | 401 | — | correct |

`check_provider` mapped only 401/403 to an auth failure, so **half the providers**
reported a bad key as a generic error with no "regenerate your key" remediation.

Rather than special-casing one vendor, every probe now keeps its response body and
a single `rejected_key` predicate maps each vendor's shape. The failure is reported
under the vendor's true code (`Auth failed (HTTP 400)`) instead of a fabricated 401.
A probe body can echo a redacted copy of the key (OpenAI's does), so it stays in its
mode-600 temp file: inspected, never printed, removed immediately.

## 2. Connection failures rendered as `Error (HTTP 000000)`

On a failed transfer curl writes `000` through `-w` **and** exits non-zero. The
`|| echo "000"` guard (present so `set -e` would not abort) appended a second
`000`, producing `000000` — which missed the `== "000"` timeout branch. All four
probes were affected.

The suite hid this: `shadow_curl`'s stub always exited 0, so the branch its
"connection timeout" test claimed to cover never ran. The stub now exits 7 on
`000` as the real binary does, which makes that test real.

## 3. The Perplexity probe rejected its own request

The probe asked for `max_tokens:1`. Perplexity's floor is 16 (`max_tokens must be
at least 16`), so it answered **400 to our own request** — meaning every valid
Perplexity key has been reporting `Error (HTTP 400)`.

A stubbed curl cannot notice a vendor rejecting our payload, so the guard asserts
the payload we send obeys the floor.

## Verification

- 358 tests pass (`bash tests/run_tests.sh`), up from 354.
- Each fix was driven test-first, and the boundary guard was checked to be
  non-vacuous (it fails against an over-broad implementation).
- Verified end-to-end against the **live** APIs: bogus keys now yield
  `Auth failed (HTTP 400)  fix: key rejected - regenerate it` for both Gemini and
  Grok, and a real-key run reports `6/6 providers available` (previously 5/6,
  with Perplexity falsely broken).