### PR TITLE
Stop a typo'd model name reading as a rejected API key (plus probe comment/coverage fixes)

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -53,7 +53,7 @@ bats --verbose-run tests/cache.bats
 | `format-output.bats` | 11 tests | defensive parsing: empty/missing/non-string responses, raw preservation, fallback-note rendering |
 | `prompts.bats` | 11 tests | template loading, {{VAR}} interpolation, role-injection rendering |
 | `agent-analysis.bats` | 11 tests | validate-analysis.sh contract enforcement, schema sync |
-| `check-status.bats` | 16 tests | two-tier CLI availability, remediation strings, HTTP probe branches, rejected-key classification (Gemini/xAI answer a bad key with 400, not 401), transfer-failure exit codes, Perplexity's minimum max_tokens, keys off the curl argv, ms clock |
+| `check-status.bats` | 25 tests | two-tier CLI availability, remediation strings, HTTP probe branches (401/403/500/000), rejected-key classification (Gemini/xAI answer a bad key with 400, not 401) and its false-positive guards (a typo'd model is not a bad key), transfer-failure exit codes, curl writing nothing, unusable jq, Perplexity's minimum max_tokens, `-X POST` and `--max-time` on every probe, temp-file cleanup, keys off the curl argv, ms clock |
 | `jobs.bats` | 16 tests | job store, --async lifecycle, --result/--jobs/--cancel, self-ignoring cache dir |
 | `stop-gate.bats` | 10 tests | opt-in gating, loop guards, BLOCK verdict, fail-open |
 | `theme.bats` | 24 tests | terminal theme detection, theme-aware emphasis + muted-text (faint/gray) rendering |
@@ -64,7 +64,7 @@ bats --verbose-run tests/cache.bats
 | `release.bats` | 5 tests | release.sh version bump/commit/tag, staged-index guard, green-suite gate |
 | `retry.bats` | 6 tests | curl_with_retry backoff + status handling, curl_secret_config off-argv config file |
 
-**Total: 358 tests** across 23 `.bats` files.
+**Total: 367 tests** across 23 `.bats` files.
 
 ### Hermetic CLI Fixture
 

--- a/scripts/check-status.sh
+++ b/scripts/check-status.sh
@@ -24,12 +24,18 @@ now_ms() {
     python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || echo $(( $(date +%s) * 1000 ))
 }
 
-# Check a single provider
-# Usage: check_provider <name> <api_key_var> <model_var> <default_model> <test_endpoint> <test_payload>
-# Vendors disagree on how a rejected key comes back. OpenAI and Perplexity send
-# 401, but Gemini sends 400 with status INVALID_ARGUMENT and xAI sends 400 with
-# code invalid-argument. For those two the response body, not the status alone,
-# separates a rejected key from a genuinely malformed request.
+# Does a 400 from this provider mean the key was rejected?
+# Usage: rejected_key <provider> <body_file>
+#
+# Vendors disagree on how a rejected key comes back. Most answer 401, which the
+# status code alone classifies. Gemini answers 400 with status INVALID_ARGUMENT
+# and xAI answers 400 with code invalid-argument; for those two the response
+# body, not the status alone, separates a rejected key from a malformed request.
+#
+# Each probe below is a request with no caller-supplied parameters beyond the
+# Gemini model in its path, and an unknown model answers 404, so on these
+# endpoints a 400 carrying the vendor's marker can only be the key. A probe that
+# grows query parameters would need a narrower test than the status alone.
 rejected_key() {
     local provider="$1" body_file="$2"
     case "$provider" in
@@ -39,6 +45,8 @@ rejected_key() {
     esac
 }
 
+# Check a single provider
+# Usage: check_provider <name> <api_key_var> <model_var> <default_model>
 check_provider() {
     local name="$1"
     local api_key="${!2:-}"
@@ -57,9 +65,10 @@ check_provider() {
 
     # Keys travel via a mode-600 curl --config file, never the argv (ps-visible)
     # or the URL. Mirrors the provider scripts' curl_secret_config hardening.
-    # The response body is kept because some vendors only reveal a rejected key
-    # there. It can carry a redacted copy of the key, so it stays in its
-    # mode-600 temp file: inspected, never printed, and removed straight after.
+    # The response body is captured because some vendors only reveal a rejected
+    # key there. It can carry a redacted copy of the key, so it lives in a temp
+    # file that mktemp creates mode-600: inspected via jq, never printed, and
+    # unlinked before this function returns.
     local http_code cfg body_file rejected
     body_file=$(mktemp)
     case "$name" in
@@ -99,9 +108,10 @@ check_provider() {
             ;;
     esac
 
-    # On a failed transfer curl writes 000 through -w and also exits non-zero.
-    # The `|| true` above absorbs that exit for set -e without appending a
-    # second 000 to the code. An empty code means curl wrote nothing at all.
+    # curl exits non-zero when a transfer fails, so the `|| true` above keeps
+    # set -e from aborting. When no response status was received it also reports
+    # the code as 000 through -w. An empty code means curl wrote nothing to
+    # stdout.
     http_code="${http_code:-000}"
 
     rejected=0
@@ -110,7 +120,7 @@ check_provider() {
     fi
     rm -f "$body_file"
     if (( rejected )); then
-        # Report the auth failure under the vendor's true code, not an invented 401
+        # This branch only runs on 400, so report it under the code the vendor sent
         echo "auth_error:400"
         return
     fi

--- a/scripts/check-status.sh
+++ b/scripts/check-status.sh
@@ -10,6 +10,13 @@ source "$SCRIPT_DIR/lib/providers.sh"
 source "$SCRIPT_DIR/lib/retry.sh"
 resolve_grok_key
 
+# Only rejected_key needs jq, and only to read a 400 body. Warn instead of
+# aborting, because every other probe result stands without it; staying silent
+# would report a rejected Gemini or xAI key as an ordinary HTTP 400.
+if ! jq --version >/dev/null 2>&1; then
+    echo "Warning: jq not found; a rejected Gemini or xAI key will report as a generic HTTP 400." >&2
+fi
+
 # Colors
 BLUE='\033[34m'
 WHITE='\033[37m'
@@ -28,20 +35,36 @@ now_ms() {
 # Usage: rejected_key <provider> <body_file>
 #
 # Vendors disagree on how a rejected key comes back. Most answer 401, which the
-# status code alone classifies. Gemini answers 400 with status INVALID_ARGUMENT
-# and xAI answers 400 with code invalid-argument; for those two the response
-# body, not the status alone, separates a rejected key from a malformed request.
+# status code alone classifies. Gemini and xAI answer 400, so for those two the
+# response body has to separate a rejected key from a malformed request.
 #
-# Each probe below is a request with no caller-supplied parameters beyond the
-# Gemini model in its path, and an unknown model answers 404, so on these
-# endpoints a 400 carrying the vendor's marker can only be the key. A probe that
-# grows query parameters would need a narrower test than the status alone.
+# Both bury the key signal under a marker they also use for unrelated faults:
+# Gemini's INVALID_ARGUMENT is its status for the whole 400 class, including a
+# model name that fails its format check, and xAI files an unknown model under
+# the same invalid-argument code as a bad key. Matching on those alone tells a
+# user with a typo in their model to regenerate a working key, so each test reads
+# the field that names the key: Gemini's details[].reason, xAI's error text.
+#
+# jq errors (missing key, wrong type, unparseable body) mean the vendor's marker
+# is absent, which is not evidence of a rejected key, so they resolve to false.
 rejected_key() {
     local provider="$1" body_file="$2"
     case "$provider" in
-        gemini) jq -e '.error.status == "INVALID_ARGUMENT"' "$body_file" >/dev/null 2>&1 ;;
-        grok)   jq -e '.code == "invalid-argument"' "$body_file" >/dev/null 2>&1 ;;
-        *)      return 1 ;;
+        gemini)
+            jq -e 'try any(.error.details[]?; .reason == "API_KEY_INVALID") catch false' \
+                "$body_file" >/dev/null 2>&1
+            ;;
+        grok)
+            # xAI offers no structured reason, so the error text is the only
+            # discriminator. Should it ever be reworded past "api key", a rejected
+            # key degrades to a plain HTTP 400: the safe direction to fail, unlike
+            # matching the code alone, which would urge a good key be regenerated.
+            jq -e 'try ((.code == "invalid-argument")
+                        and ((.error | type) == "string")
+                        and (.error | ascii_downcase | contains("api key"))) catch false' \
+                "$body_file" >/dev/null 2>&1
+            ;;
+        *)  return 1 ;;
     esac
 }
 
@@ -65,12 +88,15 @@ check_provider() {
 
     # Keys travel via a mode-600 curl --config file, never the argv (ps-visible)
     # or the URL. Mirrors the provider scripts' curl_secret_config hardening.
-    # The response body is captured because some vendors only reveal a rejected
-    # key there. It can carry a redacted copy of the key, so it lives in a temp
-    # file that mktemp creates mode-600: inspected via jq, never printed, and
-    # unlinked before this function returns.
+    # Gemini and xAI reveal a rejected key only in the response body, so theirs is
+    # kept in a temp file that mktemp creates mode-600: read by jq, never printed,
+    # and unlinked before this function returns. A signal that lands mid-probe
+    # leaves it, and the config file holding the key, behind; trapping the signal
+    # here would make Ctrl-C stop interrupting the probe.
     local http_code cfg body_file rejected
-    body_file=$(mktemp)
+    # An explicit template keeps the file in TMPDIR on every platform, since a
+    # bare mktemp ignores TMPDIR on BSD, and names it for anyone reading the dir.
+    body_file=$(mktemp "${TMPDIR:-/tmp}/council-probe.XXXXXX")
     case "$name" in
         gemini)
             cfg=$(curl_secret_config "x-goog-api-key: ${api_key}")
@@ -80,8 +106,10 @@ check_provider() {
             rm -f "$cfg"
             ;;
         openai)
+            # No body is kept: OpenAI marks a rejected key with 401, and its error
+            # body echoes a redacted copy of the key that nothing here reads.
             cfg=$(curl_secret_config "Authorization: Bearer ${api_key}")
-            http_code=$(curl -s -o "$body_file" -w "%{http_code}" --max-time 10 \
+            http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
                 --config "$cfg" \
                 "https://api.openai.com/v1/models" 2>/dev/null || true)
             rm -f "$cfg"
@@ -98,7 +126,7 @@ check_provider() {
             # a (billable) chat request. The API rejects anything under 16 output
             # tokens, so 16 is as close to free as the status check can get.
             cfg=$(curl_secret_config "Authorization: Bearer ${api_key}")
-            http_code=$(curl -s -o "$body_file" -w "%{http_code}" --max-time 10 \
+            http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
                 -X POST \
                 --config "$cfg" \
                 -H "Content-Type: application/json" \

--- a/tests/check-status.bats
+++ b/tests/check-status.bats
@@ -113,8 +113,23 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Auth failed (HTTP 401)"* ]]
     [[ "$output" == *"key rejected - regenerate it"* ]]
+    # Every API provider must classify 401, not just whichever one happens to be
+    # first: a substring match alone cannot tell four rows from one.
+    [ "$(auth_failures "$output")" -eq 4 ]
     # Only the two CLI providers remain available
     [[ "$output" == *"2/6 providers available"* ]]
+}
+
+# Gemini answers 403 PERMISSION_DENIED for a referer-restricted key, OpenAI for a
+# region block. Without the 403 arm these lose their remediation line entirely.
+@test "check-status: HTTP 403 reports auth failure with regenerate remediation" {
+    shadow_curl
+    export COUNCIL_FAKE_HTTP_CODE=403
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Auth failed (HTTP 403)"* ]]
+    [[ "$output" == *"key rejected - regenerate it"* ]]
+    [ "$(auth_failures "$output")" -eq 4 ]
 }
 
 @test "check-status: HTTP 500 reports a generic error with the code" {
@@ -123,6 +138,8 @@ EOF
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Error (HTTP 500)"* ]]
+    # A server-side fault is not a credentials problem
+    [ "$(auth_failures "$output")" -eq 0 ]
     [[ "$output" == *"2/6 providers available"* ]]
 }
 
@@ -164,7 +181,8 @@ auth_failures() {
 @test "check-status: Gemini 400 with an INVALID_ARGUMENT body reports auth failure" {
     shadow_curl
     export COUNCIL_FAKE_HTTP_CODE=400
-    export COUNCIL_FAKE_HTTP_BODY='{"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT"}}'
+    # The details array carries API_KEY_INVALID, the only field that names the key
+    export COUNCIL_FAKE_HTTP_BODY='{"error":{"code":400,"message":"API key not valid. Please pass a valid API key.","status":"INVALID_ARGUMENT","details":[{"@type":"type.googleapis.com/google.rpc.ErrorInfo","reason":"API_KEY_INVALID","domain":"googleapis.com","metadata":{"service":"generativelanguage.googleapis.com"}}]}}'
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Auth failed (HTTP 400)"* ]]
@@ -174,6 +192,39 @@ auth_failures() {
     [[ "$output" == *"Error (HTTP 400)"* ]]
 }
 
+# Both vendors reuse their 400 marker for faults that have nothing to do with the
+# key, so these bodies are the ones that must NOT be read as a rejected key. A
+# user whose model name has a typo must not be told to regenerate a working key.
+
+@test "check-status: a Gemini 400 from a malformed model name is not a rejected key" {
+    shadow_curl
+    export COUNCIL_FAKE_HTTP_CODE=400
+    # Gemini answers a name that fails its format check with the same
+    # INVALID_ARGUMENT status it uses for a bad key, and carries no details array
+    export COUNCIL_FAKE_HTTP_BODY='{"error":{"code":400,"message":"* GetModelRequest.name: unexpected model name format\n","status":"INVALID_ARGUMENT"}}'
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    # All four API providers show the generic error: proves output was produced,
+    # so the auth-failure count below cannot pass on an empty run.
+    [ "$(printf '%s\n' "$output" | grep -c 'Error (HTTP 400)' || true)" -eq 4 ]
+    [ "$(auth_failures "$output")" -eq 0 ]
+    [[ "$output" != *"key rejected"* ]]
+}
+
+@test "check-status: an xAI 400 from an unknown model is not a rejected key" {
+    shadow_curl
+    export COUNCIL_FAKE_HTTP_CODE=400
+    # xAI files an unknown model under the same code it uses for a bad key
+    export COUNCIL_FAKE_HTTP_BODY='{"code":"invalid-argument","error":"Model not found: grok-does-not-exist"}'
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    # All four API providers show the generic error: proves output was produced,
+    # so the auth-failure count below cannot pass on an empty run.
+    [ "$(printf '%s\n' "$output" | grep -c 'Error (HTTP 400)' || true)" -eq 4 ]
+    [ "$(auth_failures "$output")" -eq 0 ]
+    [[ "$output" != *"key rejected"* ]]
+}
+
 @test "check-status: a 400 that no vendor marks as a bad key stays a generic error" {
     shadow_curl
     export COUNCIL_FAKE_HTTP_CODE=400
@@ -181,7 +232,9 @@ auth_failures() {
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
     # A malformed request is not a credentials problem; do not offer to regenerate
-    [[ "$output" == *"Error (HTTP 400)"* ]]
+    # All four API providers show the generic error: proves output was produced,
+    # so the auth-failure count below cannot pass on an empty run.
+    [ "$(printf '%s\n' "$output" | grep -c 'Error (HTTP 400)' || true)" -eq 4 ]
     [ "$(auth_failures "$output")" -eq 0 ]
     [[ "$output" != *"key rejected"* ]]
 }
@@ -227,6 +280,80 @@ EOF
     [ -n "$payload" ]
     max_tokens=$(printf '%s' "$payload" | jq -r '.max_tokens')
     [ "$max_tokens" -ge 16 ]
+    # The request is billed, so the probe must sit at the floor, not merely above it
+    [ "$max_tokens" -le 32 ]
+    # A GET on /chat/completions answers 405, rendering a working key as broken
+    grep -qxF -- '-X' "$CS_ARGV_FILE"
+    grep -qxF -- 'POST' "$CS_ARGV_FILE"
+}
+
+# Without --max-time a black-holed endpoint hangs /status indefinitely.
+@test "check-status: every probe is bounded by a request timeout" {
+    record_curl
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ -s "$CS_ARGV_FILE" ]
+    [ "$(grep -cxF -- '--max-time' "$CS_ARGV_FILE" || true)" -eq 4 ]
+}
+
+# rejected_key reads the vendor's key marker with jq. Without a working jq that
+# marker is unreadable, and a rejected key looks exactly like an ordinary 400 —
+# a wrong answer, not a missing one, from the script whose job is diagnosis.
+@test "check-status: an unusable jq is reported rather than silently misdiagnosed" {
+    shadow_curl
+    printf '#!/bin/bash\nexit 127\n' > "${BATS_TEST_TMPDIR}/fakecurl/jq"
+    chmod +x "${BATS_TEST_TMPDIR}/fakecurl/jq"
+    export COUNCIL_FAKE_HTTP_CODE=400
+    export COUNCIL_FAKE_HTTP_BODY='{"code":"invalid-argument","error":"Incorrect API key provided."}'
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"jq not found"* ]]
+}
+
+# curl can exit having written nothing at all: the binary may be absent, or a
+# --config file unreadable, in which case -w never fires and the code is empty.
+@test "check-status: curl writing nothing is classified as a failed transfer" {
+    local dir="${BATS_TEST_TMPDIR}/silentcurl"
+    mkdir -p "$dir"
+    printf '#!/bin/bash\nexit 127\n' > "$dir/curl"
+    chmod +x "$dir/curl"
+    export PATH="$dir:$PATH"
+    export GEMINI_API_KEY=k OPENAI_API_KEY=k XAI_API_KEY=k PERPLEXITY_API_KEY=k
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Connection timeout"* ]]
+    [[ "$output" != *"HTTP )"* ]]
+}
+
+@test "check-status: probes whose body is never read do not write one to disk" {
+    record_curl
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ -s "$CS_ARGV_FILE" ]
+    # OpenAI's error body echoes a redacted key and nothing reads it; Perplexity's
+    # is never read either. Only Gemini and xAI keep a body.
+    [ "$(grep -c '^/dev/null$' "$CS_ARGV_FILE" || true)" -eq 2 ]
+}
+
+# A probe body and the curl config that carries the key both live in TMPDIR for
+# the length of the request. Neither may outlive the run.
+@test "check-status: a completed probe leaves no temp file behind" {
+    export TMPDIR="${BATS_TEST_TMPDIR}/tmpdir"
+    mkdir -p "$TMPDIR"
+    shadow_curl
+    export COUNCIL_FAKE_HTTP_CODE=200
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ -z "$(ls -A "$TMPDIR")" ]
+}
+
+@test "check-status: a keyless provider never creates a temp file at all" {
+    export TMPDIR="${BATS_TEST_TMPDIR}/tmpdir"
+    mkdir -p "$TMPDIR"
+    # setup() unsets every provider key, so each probe must return before mktemp
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [ -z "$(ls -A "$TMPDIR")" ]
 }
 
 @test "check-status: probe API keys never appear on the curl argv" {

--- a/tests/check-status.bats
+++ b/tests/check-status.bats
@@ -1,5 +1,5 @@
 #!/usr/bin/env bats
-# ABOUTME: Tests for check-status.sh two-tier availability and remediation output
+# ABOUTME: Tests check-status.sh provider probes, rejected-key classification, and remediation
 # ABOUTME: Hermetic via fake CLIs and a shadow curl; no real keys or network
 
 load test_helper
@@ -61,14 +61,16 @@ setup() {
     [[ "$output" == *"install the Antigravity CLI (agy)"* ]]
 }
 
-# Shadow curl with a stub that echoes a scripted HTTP code, so check_provider's
-# result branches can be exercised offline with no real keys or network. Keys
-# are dummy values only to get past the no_key guard.
+# Shadow curl with a stub that writes a scripted body to curl's -o target and
+# echoes a scripted HTTP code, so check_provider's result branches can be
+# exercised offline with no real keys or network. Keys are dummy values only to
+# get past the no_key guard.
 #
 # The stub exits non-zero on a failed transfer (code 000) because that is what
-# the real binary does: curl writes 000 through -w and *also* exits 7. A stub
-# that always succeeds cannot exercise the script's transfer-failure branch, so
-# it would certify that branch as working while it is broken.
+# the real binary does: curl writes 000 through -w and also exits non-zero (7 on
+# a refused connection, 28 on a timeout), and the stub picks one such code. A
+# stub that always exits 0 would let the script's transfer-failure branch pass
+# without ever running under a non-zero curl.
 shadow_curl() {
     local dir="${BATS_TEST_TMPDIR}/fakecurl"
     mkdir -p "$dir"
@@ -133,11 +135,12 @@ EOF
     [[ "$output" == *"2/6 providers available"* ]]
 }
 
-# Gemini and xAI answer a rejected key with 400 rather than the 401 OpenAI and
-# Perplexity send, so the status code alone cannot classify it and each vendor
-# marks it differently in the body. Both bodies below are verbatim responses
-# captured from the live APIs for a bad key. Each test also asserts that exactly
-# one provider is flagged, which proves one vendor's shape cannot match another's.
+# Gemini and xAI answer a rejected key with 400 rather than a 401, so the status
+# code alone cannot classify it and each vendor marks it differently in the body.
+# The first two bodies below are what Gemini and xAI return for a rejected key;
+# the third is a 400 that no vendor marks as a credentials problem. The two
+# vendor tests each assert that exactly one provider is flagged, so neither
+# vendor's body shape can satisfy the other's rule.
 
 # Count the providers reported as an auth failure (one row per provider).
 auth_failures() {
@@ -213,7 +216,7 @@ EOF
 # Perplexity is the one provider probed with a chat request, and it rejects any
 # request below 16 output tokens with HTTP 400 ("max_tokens must be at least
 # 16"). A probe cheaper than the floor is not a cheaper probe, it is a broken
-# one, and the stubbed curl above cannot notice: only the payload we send can.
+# one, and record_curl cannot notice: only the payload we send can.
 @test "check-status: the Perplexity probe requests at least the API's minimum max_tokens" {
     record_curl
     run bash "$SCRIPT"


### PR DESCRIPTION
A four-agent review of #7 found no defect in the fixes themselves, but the
*classifier* they added was over-broad, and the suite could not see it.

## The bug: a config typo tells you to revoke a working key

Neither vendor's 400 marker names the key. Gemini's `INVALID_ARGUMENT` is its
status for the whole 400 class; xAI files an unknown model under the same
`invalid-argument` code. Reproduced against the **live** APIs with a valid key,
varying only the model:

```
GEMINI_MODEL=gemini-3.1-pro-preview  ->  Connected
GEMINI_MODEL=Gemini-3.1-Pro-Preview  ->  Auth failed (HTTP 400)
                                         fix: key rejected - regenerate it
```

The user revokes a working key and the symptom persists. A *well-formed but
unknown* model answers 404, which is exactly why the earlier check looked safe.

Each test now reads the field that **names the key**: Gemini's
`details[].reason == "API_KEY_INVALID"`, xAI's error text. xAI publishes no
structured reason, so a reword past `"api key"` degrades a rejected key to a
plain 400 — the safe direction to fail, unlike matching the code alone, which
urges a good key be regenerated.

## Why the suite was green

The Gemini fixture had been trimmed to exactly the fields the old predicate read,
so it could not falsify it. **A fixture reduced to what the assertion inspects
cannot disprove the assertion.** It now carries the `details` array the live API
sends.

Mutation testing: of **10 defects injected into `check-status.sh`, 8 survived**
the old suite. All 10 now fail it. New coverage for 403; for 401/403 reaching
*every* provider rather than whichever row matched first; for curl writing
nothing; for `-X POST` and `--max-time`; for temp-file cleanup; and a cost bound
on the billable Perplexity probe, whose `-ge 16` assertion admitted `9999`.

## Also

- **Secret hygiene:** `rejected_key` handles only gemini and grok, yet all four
  probes wrote a response body to disk. OpenAI's error body echoes a redacted
  copy of the key. Those two now discard it.
- **Silent failure:** a missing `jq` made every `jq` error look like "not a
  rejected key", so a genuinely rejected key reported as an ordinary 400 — a
  wrong answer, not a missing one, from the script whose job is diagnosis. It
  warns now.
- **Comments:** `rejected_key()` had been inserted between `check_provider`'s
  header comment and `check_provider`, so `# Usage: check_provider ...` headed
  the wrong function; that usage line was also provably false (six params, four
  read). Several comments documented the diff rather than the code.
- **curl's contract**, verified against the binary: `000` appears only when no
  response status was received. Headers-then-stall yields the real status with a
  non-zero exit (`200`, exit 28).

## Not done, deliberately

A `trap` to clean temp files on Ctrl-C was tried and **reverted**: `trap … INT`
makes SIGINT non-fatal, so `/status` would no longer stop on Ctrl-C. The orphaned
`curl --config` file (which holds the key in plaintext) predates this work and
deserves its own change with real signal tests.

367 tests pass; bats green on Ubuntu and macOS.