### PR TITLE
Make shellcheck pass, and make it a gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,12 +32,21 @@ jobs:
         run: bash tests/run_tests.sh
 
   shellcheck:
-    name: shellcheck (advisory)
+    name: shellcheck
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+
+      # Pinned, because this job blocks a merge: an unpinned linter can redden
+      # main on a release nobody touched. Bump deliberately, with the tree clean.
       - name: Install shellcheck
-        run: sudo apt-get update && sudo apt-get install -y shellcheck
+        env:
+          SHELLCHECK_VERSION: v0.11.0
+        run: |
+          curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/${SHELLCHECK_VERSION}/shellcheck-${SHELLCHECK_VERSION}.linux.x86_64.tar.xz" \
+            | sudo tar -xJf - --strip-components=1 -C /usr/local/bin "shellcheck-${SHELLCHECK_VERSION}/shellcheck"
+          shellcheck --version
+
+      # Reads .shellcheckrc from the repo root, which lets it follow our sourced libs.
       - name: Lint shell scripts
         run: shellcheck scripts/*.sh scripts/lib/*.sh scripts/providers/*.sh

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,6 @@
+# Every script reaches its libraries through `source "$SCRIPT_DIR/lib/x.sh"`, a
+# path shellcheck cannot resolve on its own. Left unresolved it never opens the
+# sourced file, so it reports each source line as unfollowable and every shared
+# definition as unused: 34 of the 58 findings it once raised on this tree.
+external-sources=true
+source-path=SCRIPTDIR

--- a/TESTING.md
+++ b/TESTING.md
@@ -95,6 +95,34 @@ setup() { install_fake_clis; }
 
 ---
 
+## Lint (shellcheck)
+
+CI blocks a merge on this, so run it before pushing. The tree is clean; any
+finding is one you introduced.
+
+```bash
+brew install shellcheck        # macOS
+sudo apt install shellcheck    # Ubuntu/Debian
+
+shellcheck scripts/*.sh scripts/lib/*.sh scripts/providers/*.sh
+```
+
+`.shellcheckrc` in the repo root lets it follow `source "$SCRIPT_DIR/lib/*.sh"`.
+Without it, shellcheck never opens the sourced files and calls every shared
+definition unused. CI pins the version, so a newer local shellcheck may report
+findings CI does not.
+
+Silence a finding only where the code is right and the tool is wrong, and say
+why on the line above:
+
+```bash
+# Ordering by mtime is the point, and find offers no portable way to sort.
+# shellcheck disable=SC2012
+ls -t "$dir"/*.json
+```
+
+---
+
 ## Manual Tests
 
 Manual testing procedures for features that require API calls or Claude Code integration.

--- a/scripts/check-status.sh
+++ b/scripts/check-status.sh
@@ -298,15 +298,15 @@ format_status "Antigravity" "antigravity" "$antigravity_status"
 
 echo ""
 
-# Summary. available=$((...)) rather than ((available++)): under set -e a
-# post-increment returning 0 would abort the script on the first hit.
-available=0
-[[ "$gemini_status" == ok:* ]] && available=$((available + 1))
-[[ "$openai_status" == ok:* ]] && available=$((available + 1))
-[[ "$grok_status" == ok:* ]] && available=$((available + 1))
-[[ "$perplexity_status" == ok:* ]] && available=$((available + 1))
-[[ "$codex_status" == ok:* ]] && available=$((available + 1))
-[[ "$antigravity_status" == ok:* ]] && available=$((available + 1))
+# Summary. available_count=$((...)) rather than ((available_count++)): under
+# set -e a post-increment returning 0 would abort the script on the first hit.
+available_count=0
+[[ "$gemini_status" == ok:* ]] && available_count=$((available_count + 1))
+[[ "$openai_status" == ok:* ]] && available_count=$((available_count + 1))
+[[ "$grok_status" == ok:* ]] && available_count=$((available_count + 1))
+[[ "$perplexity_status" == ok:* ]] && available_count=$((available_count + 1))
+[[ "$codex_status" == ok:* ]] && available_count=$((available_count + 1))
+[[ "$antigravity_status" == ok:* ]] && available_count=$((available_count + 1))
 
-echo -e "${DIM}${available}/6 providers available${RESET}"
+echo -e "${DIM}${available_count}/6 providers available${RESET}"
 echo ""

--- a/scripts/lib/display.sh
+++ b/scripts/lib/display.sh
@@ -149,6 +149,9 @@ council_detect_theme() {
     esac
 
     if [[ "${COUNCIL_NO_TTY_QUERY:-0}" != 1 && -r /dev/tty && -w /dev/tty ]]; then
+        # The trailing \\ is printf's escape for one backslash, terminating the
+        # OSC with ST (ESC \). shellcheck reads it as a botched quote escape.
+        # shellcheck disable=SC1003
         printf '\033]11;?\033\\' > /dev/tty 2>/dev/null || true
         # Read the reply one byte at a time. bash 3.2 rejects a fractional
         # read -t, and its -d captures only an ST (ESC \) terminator — so a

--- a/scripts/lib/export.sh
+++ b/scripts/lib/export.sh
@@ -17,7 +17,8 @@ write_export() {
     local providers="$3"  # Space-separated list like "gemini openai"
 
     # Ensure directory exists
-    local dir=$(dirname "$output_path")
+    local dir
+    dir=$(dirname "$output_path")
     [[ -d "$dir" ]] || mkdir -p "$dir"
 
     # Generate metadata header

--- a/scripts/lib/jobs.sh
+++ b/scripts/lib/jobs.sh
@@ -80,6 +80,9 @@ jobs_prune() {
     local max="${COUNCIL_MAX_JOBS:-20}"
     local dir f status
     dir=$(jobs_state_dir)
+    # Ordering by mtime is the point, and find offers no portable way to sort.
+    # The names are job ids this file generates, so they hold no whitespace.
+    # shellcheck disable=SC2012
     ls -t "$dir"/*.json 2>/dev/null | tail -n +$((max + 1)) | while read -r f; do
         status=$(jq -r '.status' "$f" 2>/dev/null || echo "")
         case "$status" in

--- a/scripts/lib/pane-watcher.sh
+++ b/scripts/lib/pane-watcher.sh
@@ -8,6 +8,7 @@ trap 'rm -rf "$WATCH"' EXIT
 # render.sh picks emphasis colors by theme. Detection runs here because the
 # pane's own tty answers the OSC 11 background query; an explicit
 # COUNCIL_THEME (forwarded via tmux -e) wins inside council_detect_theme.
+# shellcheck source=display.sh
 source "$DISPLAY_LIB"
 COUNCIL_THEME_RESOLVED=$(council_detect_theme)
 export COUNCIL_THEME_RESOLVED
@@ -29,9 +30,13 @@ provider_index() {
         [[ "${provider_names[$i]}" == "$name" ]] && { printf -v "$__out" '%d' "$i"; return; }
         i=$((i + 1))
     done
-    provider_names[$i]="$name"
+    provider_names[i]="$name"
     printf -v "$__out" '%d' "$i"
 }
+
+# build_banner_line writes here through printf -v, which creates the variable
+# rather than reading it, so nothing else declares it.
+banner_line=""
 
 status_lines_processed=0
 shown_responses=""
@@ -133,9 +138,9 @@ while true; do
             line=$(sed -n "${status_lines_processed}p" "$WATCH/status")
             IFS=$'\t' read -r provider state ms model <<<"$line"
             provider_index idx "$provider"
-            provider_states[$idx]="$state"
-            [[ -n "$ms" ]] && provider_timings[$idx]="$ms"
-            [[ -n "$model" ]] && provider_models[$idx]="$model"
+            provider_states[idx]="$state"
+            [[ -n "$ms" ]] && provider_timings[idx]="$ms"
+            [[ -n "$model" ]] && provider_models[idx]="$model"
             if [[ "$state" == "error" ]]; then
                 clear_loading
                 printf '\n\033[1;38;2;185;28;28m✗ %s error\033[0m\n' "$provider"
@@ -173,6 +178,9 @@ while true; do
             # gating on it would suppress marks that DO work in iTerm2+tmux. The
             # DCS passthrough needs tmux `allow-passthrough on` to reach iTerm2;
             # other terminals safely ignore the unknown OSC 1337.
+            # The trailing \\ is printf's escape for the one backslash that ends
+            # the tmux DCS passthrough (ESC \), not a botched quote escape.
+            # shellcheck disable=SC1003
             printf '\033Ptmux;\033\033]1337;SetMark\a\033\\'
             build_banner_line banner_line "$name"
             printf '\n\n%s\n\n' "$banner_line"

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -80,11 +80,11 @@ api_key_present() {
 prefer_cli_over_api() {
     # Space-padded set string for bash 3.2 compat (no associative arrays).
     # Padding ensures word-boundary matches (e.g., "ai" won't match in "openai").
-    local available=" $* "
+    local requested=" $* "
     local p out=() shadow_cli
     for p in "$@"; do
         shadow_cli=$(shadow_origin "$p")
-        if [[ -n "$shadow_cli" && "$available" == *" $shadow_cli "* ]]; then
+        if [[ -n "$shadow_cli" && "$requested" == *" $shadow_cli "* ]]; then
             continue
         fi
         out+=("$p")

--- a/scripts/lib/roles.sh
+++ b/scripts/lib/roles.sh
@@ -184,14 +184,14 @@ assign_roles_to_providers() {
 
     IFS=',' read -ra roles <<< "$roles_str"
 
-    local assignments=()
+    local pairs=()
     for i in "${!providers[@]}"; do
         local provider="${providers[$i]}"
         local role="${roles[$i]:-}"  # Empty if no role for this provider
-        assignments+=("${provider}:${role}")
+        pairs+=("${provider}:${role}")
     done
 
-    echo "${assignments[*]}"
+    echo "${pairs[*]}"
 }
 
 # Get role for a specific provider from assignments string

--- a/scripts/lib/verbosity.sh
+++ b/scripts/lib/verbosity.sh
@@ -2,8 +2,12 @@
 # ABOUTME: Shared system-prompt + verbosity directive for all providers
 # ABOUTME: Single source of truth for both the base prompt and verbosity levels
 
-# Base system prompt — used by all four providers. Edit here to change
-# the persona globally. Perplexity appends an additional citation clause.
+# Base system prompt — used by every provider. Edit here to change the persona
+# globally. Perplexity appends an additional citation clause.
+#
+# Read by the provider scripts that source this file, which shellcheck cannot
+# see while linting this file on its own.
+# shellcheck disable=SC2034
 BASE_SYSTEM_PROMPT="You are an expert software engineering consultant. Provide clear, practical responses with code examples where helpful. Be thorough but concise - focus on actionable guidance."
 
 # Writes a verbosity directive into the named variable based on the level.

--- a/scripts/query-council.sh
+++ b/scripts/query-council.sh
@@ -526,9 +526,10 @@ RESET='\033[0m'
 # Format provider list with colors and emojis
 format_providers() {
     local formatted=""
+    local color emoji
     for p in "$@"; do
-        local color=$(provider_color "$p")
-        local emoji=$(provider_emoji "$p")
+        color=$(provider_color "$p")
+        emoji=$(provider_emoji "$p")
         formatted+="${emoji} ${color}${p}${RESET} "
     done
     echo "$formatted"

--- a/scripts/validate-analysis.sh
+++ b/scripts/validate-analysis.sh
@@ -34,6 +34,8 @@ VIOLATIONS=$(echo "$INPUT" | jq -r '
 
 if [[ -n "$VIOLATIONS" ]]; then
     echo "invalid agent analysis:" >&2
+    # Bullets every line. ${var//search/replace} has no line anchor to match on.
+    # shellcheck disable=SC2001
     echo "$VIOLATIONS" | sed 's/^/  - /' >&2
     exit 1
 fi


### PR DESCRIPTION
The shellcheck job was `continue-on-error: true`, so the **run** stayed green
while the **check** stayed red. Every commit on `main` carried a red ✗ —
including both releases. That teaches a reader to ignore the one signal that
should stop them.

## Where the 58 findings came from

Zero were error-level. **Thirty-four came from a single blind spot:** every
script reaches its libraries via `source "$SCRIPT_DIR/lib/x.sh"`, a path
shellcheck can't resolve, so it never opened the sourced files and reported
every shared definition (`BLUE`, `BASE_SYSTEM_PROMPT`, `COUNCIL_HAS_TTY`, …) as
unused. A `.shellcheckrc` with `external-sources=true` takes 58 → 26 — and,
seeing across the source graph for the first time, it surfaced collisions it had
previously missed (`SC2178` went 2 → 9).

**Configure first, then judge the residue.** Fixing findings before teaching
shellcheck the source graph would have meant "fixing" ~34 phantom warnings in
correct code.

## The three real ones

- **`available` means three different things.** An array in `discover_providers`
  (`providers.sh:9`), a padded string in `prefer_cli_over_api` (`:83`), and a
  provider counter in `check-status.sh`. All scoped, so not a bug *today* — it's
  the shape that becomes one the day a `local` goes missing. Now
  `available_count`, `requested`, and (in `roles.sh`) `pairs`, leaving
  `assignments` to name a single concept.
- **`banner_line` silently became a global.** `build_banner_line` creates it via
  `printf -v` — the bash 3.2 out-param idiom, no namerefs — so nothing ever
  declared it. Declared now, where the loop that reads it can be seen.
- **Three `local x=$(cmd)` swallow the command's exit status.** `local` is itself
  a command, and *its* success becomes the line's, so `set -e` never sees a
  failing `dirname`. Split.

## Four where shellcheck is wrong

Disabled on the line, each with the reason above it — a bare `disable` is how a
linter rots:

- printf's `\\` is the single backslash closing an OSC with ST (`SC1003` ×2)
- `sed 's/^/  - /'` bullets *every* line; `${var//}` has no line anchor (`SC2001`)
- `ls -t` sorts by mtime, which `find` can't do portably (`SC2012`)
- `BASE_SYSTEM_PROMPT` is read by the six scripts that source it (`SC2034`)

While there, corrected a comment that claimed it was "used by all four
providers" — six use it.

## The gate

Zero findings remain, so `continue-on-error` goes. **shellcheck is pinned to
v0.11.0**: an unpinned linter that blocks a merge can redden `main` on a release
nobody touched — the same failure mode as an unpinned bats. `TESTING.md` tells
contributors how to run it locally.

## Verified

- `shellcheck` exits **0** on a clean checkout of this commit
- exits **non-zero** again on an injected violation (the gate isn't vacuous)
- **367 tests pass**
- `/status` still reports `6/6 providers available`

No behavior change.