### PR TITLE
fix(hooks): quote ${CLAUDE_PLUGIN_ROOT} in the Stop hook command (Fixes #11)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/stop-review-gate.sh",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/stop-review-gate.sh\"",
             "timeout": 120
           }
         ]


### PR DESCRIPTION
## Summary

Quotes the `${CLAUDE_PLUGIN_ROOT}` expansion in the Stop hook command. Fixes #11.

```diff
- "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/stop-review-gate.sh",
+ "command": "bash \"${CLAUDE_PLUGIN_ROOT}/scripts/stop-review-gate.sh\"",
```

## Why it matters

On Windows, Claude Code installs plugins under the user profile (`C:\Users\<name>\.claude\plugins\cache\...`). When the username contains a space — very common — the **unquoted** expansion word-splits under bash, so `bash` receives the split-off prefix as its script argument. Two failure modes:

- **exit 127** — the prefix isn't a file: noisy stderr on every Stop, and the disabled-by-default gate never runs.
- **exit 2** — a file happens to exist at the prefix: bash execs *that* file, hits a syntax error, and returns `2` — which Claude Code interprets as **"block the stop."** Because hook commands are snapshotted at plugin load, the resulting Stop-block loop survives both editing `hooks.json` and `claude plugin disable`; only `disableAllHooks` or a restart clears it.

The failure happens *before* `stop-review-gate.sh` runs, so the opt-in gate config is never even consulted — it fires for every affected user on every Stop.

## Verification

Reproduced and fixed under bash (the shell the hook engine invokes), with `CLAUDE_PLUGIN_ROOT` pointing at a spaced path and a stray file at the split prefix:

```
OLD  bash ${CLAUDE_PLUGIN_ROOT}/scripts/stop-review-gate.sh   -> syntax error, exit 2   (blocks stop)
NEW  bash "${CLAUDE_PLUGIN_ROOT}/scripts/stop-review-gate.sh" -> gate runs, exit 0       (disabled-by-default)
```

(Note: an interactive **zsh** does *not* word-split unquoted expansions, so this bug is invisible when tested there — it only manifests under the bash the hook actually runs in.)

## Scope

Just the one hook command — the spot shellcheck can't lint (it lives in a JSON string). The `${CLAUDE_PLUGIN_ROOT}` references in `commands/*.md` and `skills/*.md` are model-mediated and were reported working on a spaced path; quoting them is reasonable defense-in-depth but is intentionally left out of this minimal fix.

Reported and diagnosed with a precise repro by @syamilsahimi99-cell in #11 — thank you.

https://claude.ai/code/session_01NmsoctNj3zNzCiBZC7SnNG
