### PR TITLE
chore(models): update stale default models to current flagships

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You get side-by-side responses from each configured provider:
    UUIDv7 specifically: security of non-guessable IDs plus the index
    locality of time-ordered sequences.
 
-🟥 Grok - grok-4.20-reasoning
+🟥 Grok - grok-4.5
    BIGINT autoincrement — smaller index, faster joins. Handle public-
    exposure concerns with a separate UUID slug column.
 
@@ -467,8 +467,8 @@ Override default models via environment variables:
 
 ```bash
 export GEMINI_MODEL="gemini-3.1-pro-preview"       # default
-export OPENAI_MODEL="gpt-5.5-pro"                   # default
-export GROK_MODEL="grok-4.20-reasoning"             # default
+export OPENAI_MODEL="gpt-5.6-sol"                   # default
+export GROK_MODEL="grok-4.5"                        # default
 export PERPLEXITY_MODEL="sonar-reasoning-pro"       # default (reasoning + search)
 ```
 
@@ -493,8 +493,8 @@ The bump applies to:
 | Model Type | COUNCIL_MAX_TOKENS | Actual Limit |
 |------------|-------------------|--------------|
 | Standard (gpt-5.1) | 2048 (default) | 2048 |
-| Reasoning (gpt-5.5-pro) | 2048 (default) | 32768 |
-| Reasoning (gpt-5.5-pro) | 4096 | 32768 |
+| Reasoning (gpt-5.6-sol) | 2048 (default) | 32768 |
+| Reasoning (gpt-5.6-sol) | 4096 | 32768 |
 
 Control reasoning effort to balance speed vs thoroughness:
 

--- a/scripts/check-status.sh
+++ b/scripts/check-status.sh
@@ -224,8 +224,8 @@ echo ""
 
 # Check each provider
 gemini_status=$(check_provider "gemini" "GEMINI_API_KEY" "GEMINI_MODEL" "gemini-3.1-pro-preview")
-openai_status=$(check_provider "openai" "OPENAI_API_KEY" "OPENAI_MODEL" "gpt-5.5-pro")
-grok_status=$(check_provider "grok" "GROK_API_KEY" "GROK_MODEL" "grok-4.20-reasoning")
+openai_status=$(check_provider "openai" "OPENAI_API_KEY" "OPENAI_MODEL" "gpt-5.6-sol")
+grok_status=$(check_provider "grok" "GROK_API_KEY" "GROK_MODEL" "grok-4.5")
 perplexity_status=$(check_provider "perplexity" "PERPLEXITY_API_KEY" "PERPLEXITY_MODEL" "sonar-reasoning-pro")
 # codex login status exits non-zero when logged out; agy has no
 # equivalent offline auth probe, so it stays a single-tier check

--- a/scripts/dev/demo-pane.sh
+++ b/scripts/dev/demo-pane.sh
@@ -53,8 +53,8 @@ MD
 for p in gemini openai grok perplexity; do
     case "$p" in
         gemini)     m="gemini-3.1-pro-preview" ;;
-        openai)     m="gpt-5.5-pro" ;;
-        grok)       m="grok-4.20-reasoning" ;;
+        openai)     m="gpt-5.6-sol" ;;
+        grok)       m="grok-4.5" ;;
         perplexity) m="sonar-reasoning-pro" ;;
     esac
     pane_status_event "$PANE" "$p" querying "" "$m"
@@ -64,8 +64,8 @@ done
 model_for() {
     case "$1" in
         gemini)     echo "gemini-3.1-pro-preview" ;;
-        openai)     echo "gpt-5.5-pro" ;;
-        grok)       echo "grok-4.20-reasoning" ;;
+        openai)     echo "gpt-5.6-sol" ;;
+        grok)       echo "grok-4.5" ;;
         perplexity) echo "sonar-reasoning-pro" ;;
     esac
 }

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -105,8 +105,8 @@ default_provider_set() {
 get_model() {
     case "$1" in
         gemini)     echo "${GEMINI_MODEL:-gemini-3.1-pro-preview}" ;;
-        openai)     echo "${OPENAI_MODEL:-gpt-5.5-pro}" ;;
-        grok)       echo "${GROK_MODEL:-grok-4.20-reasoning}" ;;
+        openai)     echo "${OPENAI_MODEL:-gpt-5.6-sol}" ;;
+        grok)       echo "${GROK_MODEL:-grok-4.5}" ;;
         perplexity) echo "${PERPLEXITY_MODEL:-sonar-reasoning-pro}" ;;
         codex)      echo "${CODEX_MODEL:-gpt-5.5}" ;;
         antigravity) echo "${ANTIGRAVITY_MODEL:-Gemini 3.5 Flash (High)}" ;;

--- a/scripts/providers/grok.sh
+++ b/scripts/providers/grok.sh
@@ -39,7 +39,7 @@ fi
 ENDPOINT="https://api.x.ai/v1/chat/completions"
 
 # Model selection (override via GROK_MODEL env var)
-MODEL="${GROK_MODEL:-grok-4.20-reasoning}"
+MODEL="${GROK_MODEL:-grok-4.5}"
 
 # Token limit (override via COUNCIL_MAX_TOKENS env var). Reasoning models
 # (*-reasoning, grok-4*, grok-3-mini-*, grok-build-*) need a higher cap; for

--- a/scripts/providers/openai.sh
+++ b/scripts/providers/openai.sh
@@ -54,7 +54,7 @@ PAYLOAD_FILE=$(mktemp)
 trap 'rm -f "$CURL_CFG" "$PAYLOAD_FILE"' EXIT
 
 # Model selection (override via OPENAI_MODEL env var)
-MODEL="${OPENAI_MODEL:-gpt-5.5-pro}"
+MODEL="${OPENAI_MODEL:-gpt-5.6-sol}"
 
 # Token limit (override via COUNCIL_MAX_TOKENS env var)
 BASE_TOKENS="${COUNCIL_MAX_TOKENS:-2048}"


### PR DESCRIPTION
## Summary

Refreshes the two default model IDs that had gone stale, verified against vendor docs (July 2026). Two providers were already current and are left untouched.

| Provider | Before | After | Why |
|---|---|---|---|
| **OpenAI** | `gpt-5.5-pro` | `gpt-5.6-sol` | GPT-5.6 reached GA 2026-07-09; **Sol** is the flagship reasoning/coding tier. Chose the explicit ID over the `gpt-5.6` alias (the alias hot-swaps, which would drift the cache key / pane header). |
| **Grok** | `grok-4.20-reasoning` | `grok-4.5` | xAI's docs name `grok-4.5` the recommended flagship. The old string wasn't even an exact ID (the real dated variant is `grok-4.20-0309-reasoning`). |

**Left unchanged — already current:**
- **Gemini** `gemini-3.1-pro-preview` — still the top Pro model; there is no `gemini-3.5-pro` (3.5 is Flash-tier only).
- **Perplexity** `sonar-reasoning-pro` — still the current reasoning model.
- **Antigravity** `Gemini 3.5 Flash (High)` — matches the current top Flash (`gemini-3.5-flash`).
- **Codex** `gpt-5.5` — this mirrors the **codex CLI's own default**, not a web-published model. The installed CLI (`codex-cli 0.137.0`) resolves its default internally and doesn't expose it locally, so I left it rather than guess and make the cache-key/pane-header mirror wrong. Worth verifying against the CLI separately.

## Compatibility (checked, not assumed)

The provider scripts gate behavior on model-family globs — both new IDs still match:
- `gpt-5.6-sol` matches `gpt-5.[4-9]*` → routes to `/v1/responses` and gets the reasoning token-bump (`openai.sh`).
- `grok-4.5` matches `grok-4*` → still gets the reasoning token-bump (`grok.sh`).

No routing/token-bump pattern needed changing (the README's documented pattern lists are unchanged for the same reason).

## Scope

Synced every place a default lives, so they can't drift:
`scripts/lib/providers.sh` (`get_model`), `scripts/providers/{openai,grok}.sh`, `scripts/check-status.sh` probes, `scripts/dev/demo-pane.sh`, and `README.md` (config example, sample-transcript label, token-table rows).

## Verification

- `shellcheck` clean on all tracked `*.sh`.
- `bats` passing on the model-relevant suites: `tokens.bats` (9/9), `providers.bats` (16/16), `check-status.bats` (25/25), `cache.bats` (26/26). No test pins a default — they set `*_MODEL` explicitly — so the change is behavior-preserving for the suite; CI runs the full suite on ubuntu + macOS.

## One judgment call for the reviewer

`gpt-5.6-sol` reached GA **the day before** this change (2026-07-09). It's the current flagship and GA, but if you'd rather let a brand-new model settle, `gpt-5.5-pro` is still available — pin it via `OPENAI_MODEL`. Flagging so the aggressiveness is a deliberate choice.

https://claude.ai/code/session_01NmsoctNj3zNzCiBZC7SnNG
