### PR TITLE
feat(providers): add image input to grok and perplexity

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,9 +311,8 @@ Attach one image (e.g. a UI screenshot) so vision-capable providers can critique
 ```
 
 - Single image per query, raw size up to 10 MB, extensions: png / jpg / jpeg / webp / gif.
-- `gemini` and `openai` receive the image alongside the prompt.
+- `gemini`, `openai`, `grok`, and `perplexity` receive the image alongside the prompt.
 - CLI providers answer through their vision sibling: `codex` via `openai`, `antigravity` via `gemini` (the slot is marked as a fallback). If the sibling is unusable (no API key) or already answering in its own slot, the CLI provider answers text-only instead.
-- `grok` and `perplexity` answer text-only; their responses are prefixed with `(answered without the image)`.
 
 Privacy: the image is sent to the providers that can see it, but its bytes are **not** written to cache entries or the saved `council-*.md` transcripts — only a hash of the image keys the cache.
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -57,7 +57,7 @@ bats --verbose-run tests/cache.bats
 | `jobs.bats` | 16 tests | job store, --async lifecycle, --result/--jobs/--cancel, self-ignoring cache dir |
 | `stop-gate.bats` | 10 tests | opt-in gating, loop guards, BLOCK verdict, fail-open |
 | `theme.bats` | 24 tests | terminal theme detection, theme-aware emphasis + muted-text (faint/gray) rendering |
-| `providers.bats` | 16 tests | API provider payloads, response parsing, endpoint routing, secret/payload hygiene, vision image injection (gemini inlineData, openai input_image/image_url) |
+| `providers.bats` | 19 tests | API provider payloads, response parsing, endpoint routing, secret/payload hygiene, vision image injection (gemini inlineData, openai input_image/image_url, grok/perplexity image_url) |
 | `image.bats` | 8 tests | --image validation (missing/bad-type/oversize), vision routing, CLI→sibling routing, non-vision text-only tag, base64 never in the cache |
 | `pane-watcher.bats` | 3 tests | standalone pane watcher: banner + response render, error notice, SetMark, watch-dir cleanup |
 | `export.bats` | 5 tests | markdown transcript export writing + formatting |
@@ -472,11 +472,11 @@ rm combined-test.md
 
 **Test A**: Attach an image to vision-capable providers
 ```bash
-/claude-council:ask --image=screenshot.png --providers=gemini,openai "What does this screen show?"
+/claude-council:ask --image=screenshot.png --providers=gemini,openai,grok,perplexity "What does this screen show?"
 ```
 
 **Expected**:
-- [ ] Gemini and OpenAI describe the actual image content (they received it)
+- [ ] Gemini, OpenAI, Grok, and Perplexity describe the actual image content (they received it)
 - [ ] No base64 appears in the terminal output or the saved `council-*.md` transcript
 
 **Test B**: Default set routes CLI providers to their vision siblings
@@ -486,7 +486,6 @@ rm combined-test.md
 
 **Expected**:
 - [ ] codex's slot is answered by openai and antigravity's by gemini (marked as a fallback), both seeing the image
-- [ ] grok / perplexity answer text-only, prefixed `(answered without the image)`
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -154,13 +154,12 @@ temp file, and folds only its SHA-256 into the cache key (`COUNCIL_IMAGE_HASH`) 
 the bytes never enter the prompt string.
 
 Per-provider disposition when an image is attached:
-- **gemini, openai** (vision-capable) receive the image — gemini as an
-  `inlineData` part, openai as `input_image` (Responses API) or `image_url`
-  (Chat Completions).
+- **gemini, openai, grok, perplexity** (vision-capable) receive the image —
+  gemini as an `inlineData` part, openai as `input_image` (Responses API) or
+  `image_url` (Chat Completions), grok and perplexity as an OpenAI-compatible
+  `image_url` data-URI on their `/chat/completions` endpoint.
 - **codex, antigravity** (CLI, cannot accept an image) route to their vision
   API sibling — codex→openai, antigravity→gemini — with the image.
-- **grok, perplexity** (no vision model) answer text-only; their response is
-  prefixed `(answered without the image)`.
 
 Privacy invariant: only the image's SHA-256 keys the cache. The base64 lives
 solely in a temp file passed to providers; it is never written to cache entries

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -118,7 +118,7 @@ get_model() {
 # vision set; everything else routes to a sibling or answers text-only.
 provider_vision_capable() {
     case "$1" in
-        gemini|openai) return 0 ;;
+        gemini|openai|grok|perplexity) return 0 ;;
         *) return 1 ;;
     esac
 }

--- a/scripts/providers/grok.sh
+++ b/scripts/providers/grok.sh
@@ -17,11 +17,23 @@ verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
 DEBUG="${COUNCIL_DEBUG:-}"
 
 PROMPT="${1:-}"
+IMAGE_FILE=""
+IMAGE_MIME=""
 # A large prompt (e.g. a big --file) arrives via a temp file to stay off
 # the process argv, where the OS would reject it as "argument list too long".
 if [[ "$PROMPT" == "--prompt-file" ]]; then
     PROMPT=$(cat "${2:?--prompt-file requires a path}")
+    shift 2
+elif [[ $# -gt 0 ]]; then
+    shift
 fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image-file) IMAGE_FILE="${2:?--image-file requires a path}"; shift 2 ;;
+        --image-mime) IMAGE_MIME="${2:?--image-mime requires a value}"; shift 2 ;;
+        *) shift ;;
+    esac
+done
 
 if [[ -z "$PROMPT" ]]; then
     echo "Error: No prompt provided" >&2
@@ -50,18 +62,34 @@ bump_for_reasoning TOKENS "$MODEL" "$BASE_TOKENS" '*reasoning*' 'grok-4*' 'grok-
 SYSTEM="${VERBOSITY_PREFIX:+$VERBOSITY_PREFIX }$BASE_SYSTEM_PROMPT"
 
 # Build request payload
-PAYLOAD=$(jq -n --arg prompt "$PROMPT" --arg model "$MODEL" --argjson tokens "$TOKENS" --arg system "$SYSTEM" '{
-    model: $model,
-    messages: [{
-        role: "system",
-        content: $system
-    }, {
-        role: "user",
-        content: $prompt
-    }],
-    temperature: 0.7,
-    max_tokens: $tokens
-}')
+if [[ -n "$IMAGE_FILE" ]]; then
+    PAYLOAD=$(jq -n --arg prompt "$PROMPT" --arg model "$MODEL" --argjson tokens "$TOKENS" --arg system "$SYSTEM" \
+        --rawfile b64 "$IMAGE_FILE" --arg mime "$IMAGE_MIME" '{
+        model: $model,
+        messages: [
+            { role: "system", content: $system },
+            { role: "user", content: [
+                { type: "text",      text: $prompt },
+                { type: "image_url", image_url: { url: ("data:" + $mime + ";base64," + $b64) } }
+            ]}
+        ],
+        temperature: 0.7,
+        max_tokens: $tokens
+    }')
+else
+    PAYLOAD=$(jq -n --arg prompt "$PROMPT" --arg model "$MODEL" --argjson tokens "$TOKENS" --arg system "$SYSTEM" '{
+        model: $model,
+        messages: [{
+            role: "system",
+            content: $system
+        }, {
+            role: "user",
+            content: $prompt
+        }],
+        temperature: 0.7,
+        max_tokens: $tokens
+    }')
+fi
 
 # Keep the API key and request body off the process argv (ps-visible / OS
 # argument-size limits): the key travels via a mode-600 curl config file and

--- a/scripts/providers/perplexity.sh
+++ b/scripts/providers/perplexity.sh
@@ -16,11 +16,23 @@ verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
 DEBUG="${COUNCIL_DEBUG:-}"
 
 PROMPT="${1:-}"
+IMAGE_FILE=""
+IMAGE_MIME=""
 # A large prompt (e.g. a big --file) arrives via a temp file to stay off
 # the process argv, where the OS would reject it as "argument list too long".
 if [[ "$PROMPT" == "--prompt-file" ]]; then
     PROMPT=$(cat "${2:?--prompt-file requires a path}")
+    shift 2
+elif [[ $# -gt 0 ]]; then
+    shift
 fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image-file) IMAGE_FILE="${2:?--image-file requires a path}"; shift 2 ;;
+        --image-mime) IMAGE_MIME="${2:?--image-mime requires a value}"; shift 2 ;;
+        *) shift ;;
+    esac
+done
 
 if [[ -z "$PROMPT" ]]; then
     echo "Error: No prompt provided" >&2
@@ -55,13 +67,25 @@ RECENCY="${PERPLEXITY_RECENCY:-}"
 SYSTEM="${VERBOSITY_PREFIX:+$VERBOSITY_PREFIX }$BASE_SYSTEM_PROMPT When citing sources, include them inline."
 
 # Build request payload
-# Perplexity extends OpenAI format with search-specific parameters
+# Perplexity extends OpenAI format with search-specific parameters.
+# The user message content is either a bare prompt string or, when an image is
+# supplied, an OpenAI-shaped [text, image_url] array. Building it once here keeps
+# the image variant orthogonal to the recency branch below (no 2x2 duplication).
+if [[ -n "$IMAGE_FILE" ]]; then
+    USER_CONTENT=$(jq -n --arg prompt "$PROMPT" --rawfile b64 "$IMAGE_FILE" --arg mime "$IMAGE_MIME" '[
+        { type: "text",      text: $prompt },
+        { type: "image_url", image_url: { url: ("data:" + $mime + ";base64," + $b64) } }
+    ]')
+else
+    USER_CONTENT=$(jq -n --arg prompt "$PROMPT" '$prompt')
+fi
+
 if [[ -n "$RECENCY" ]]; then
     PAYLOAD=$(jq -n \
-        --arg prompt "$PROMPT" \
         --arg model "$MODEL" \
         --argjson tokens "$TOKENS" \
         --arg system "$SYSTEM" \
+        --argjson content "$USER_CONTENT" \
         --arg recency "$RECENCY" \
         '{
             model: $model,
@@ -70,7 +94,7 @@ if [[ -n "$RECENCY" ]]; then
                 content: $system
             }, {
                 role: "user",
-                content: $prompt
+                content: $content
             }],
             temperature: 0.7,
             max_tokens: $tokens,
@@ -79,10 +103,10 @@ if [[ -n "$RECENCY" ]]; then
         }')
 else
     PAYLOAD=$(jq -n \
-        --arg prompt "$PROMPT" \
         --arg model "$MODEL" \
         --argjson tokens "$TOKENS" \
         --arg system "$SYSTEM" \
+        --argjson content "$USER_CONTENT" \
         '{
             model: $model,
             messages: [{
@@ -90,7 +114,7 @@ else
                 content: $system
             }, {
                 role: "user",
-                content: $prompt
+                content: $content
             }],
             temperature: 0.7,
             max_tokens: $tokens,

--- a/tests/image.bats
+++ b/tests/image.bats
@@ -69,14 +69,16 @@ PROV
     [[ "$resp" == *"MIME=image/png"* ]]
 }
 
-@test "image: a non-vision provider runs text-only and is tagged" {
+@test "image: a non-vision provider with no vision sibling runs text-only and is tagged" {
     local fd="${BATS_TEST_TMPDIR}/fp"; mkdir -p "$fd"
-    write_echo_provider "$fd/perplexity.sh"
-    run --separate-stderr env PROVIDERS_DIR="$fd" PERPLEXITY_API_KEY=k \
+    write_echo_provider "$fd/codex.sh"
+    # No OPENAI_API_KEY: codex's vision sibling (openai) is unusable, so codex
+    # cannot route the image and answers text-only with the tag instead.
+    run --separate-stderr env PROVIDERS_DIR="$fd" \
         bash "$SCRIPT" --no-cache --no-pane --no-auto-context \
-        --image="$IMG" --providers=perplexity "look"
+        --image="$IMG" --providers=codex "look"
     [ "$status" -eq 0 ]
-    local resp; resp=$(echo "$output" | jq -r '.round1.perplexity.response')
+    local resp; resp=$(echo "$output" | jq -r '.round1.codex.response')
     [[ "$resp" == *"(answered without the image)"* ]]
     [[ "$resp" == *"IMG=|"* ]]   # empty image field: it never got the base64
 }

--- a/tests/providers.bats
+++ b/tests/providers.bats
@@ -194,12 +194,52 @@ run_provider() {
     grep -qF 'data:image/png;base64,QUJD' "$DATA_FILE"
 }
 
-@test "provider_vision_capable: true for gemini/openai, false for the rest" {
+@test "grok: injects image_url object when given an image" {
+    FAKE_BODY='{"choices":[{"message":{"content":"ok"}}]}'
+    local bf="${BATS_TEST_TMPDIR}/b64"; printf 'QUJD' > "$bf"
+    run --separate-stderr env PATH="${FAKE_DIR}:$PATH" \
+        FAKE_ARGV_FILE="$ARGV_FILE" FAKE_CONFIG_FILE="$CONFIG_FILE" \
+        FAKE_DATA_FILE="$DATA_FILE" FAKE_BODY="$FAKE_BODY" FAKE_HTTP=200 \
+        COUNCIL_RETRY_DELAY=0 XAI_API_KEY=k \
+        bash "$PROVIDERS/grok.sh" "hi" --image-file "$bf" --image-mime image/png
+    [ "$status" -eq 0 ]
+    grep -qF 'image_url' "$DATA_FILE"
+    grep -qF 'data:image/png;base64,QUJD' "$DATA_FILE"
+}
+
+@test "perplexity: injects image_url object when given an image" {
+    FAKE_BODY='{"choices":[{"message":{"content":"ok"}}]}'
+    local bf="${BATS_TEST_TMPDIR}/b64"; printf 'QUJD' > "$bf"
+    run --separate-stderr env PATH="${FAKE_DIR}:$PATH" \
+        FAKE_ARGV_FILE="$ARGV_FILE" FAKE_CONFIG_FILE="$CONFIG_FILE" \
+        FAKE_DATA_FILE="$DATA_FILE" FAKE_BODY="$FAKE_BODY" FAKE_HTTP=200 \
+        COUNCIL_RETRY_DELAY=0 PERPLEXITY_API_KEY=k \
+        bash "$PROVIDERS/perplexity.sh" "hi" --image-file "$bf" --image-mime image/png
+    [ "$status" -eq 0 ]
+    grep -qF 'image_url' "$DATA_FILE"
+    grep -qF 'data:image/png;base64,QUJD' "$DATA_FILE"
+}
+
+@test "perplexity: injects image_url object with a recency filter set" {
+    FAKE_BODY='{"choices":[{"message":{"content":"ok"}}]}'
+    local bf="${BATS_TEST_TMPDIR}/b64"; printf 'QUJD' > "$bf"
+    run --separate-stderr env PATH="${FAKE_DIR}:$PATH" \
+        FAKE_ARGV_FILE="$ARGV_FILE" FAKE_CONFIG_FILE="$CONFIG_FILE" \
+        FAKE_DATA_FILE="$DATA_FILE" FAKE_BODY="$FAKE_BODY" FAKE_HTTP=200 \
+        COUNCIL_RETRY_DELAY=0 PERPLEXITY_API_KEY=k PERPLEXITY_RECENCY=week \
+        bash "$PROVIDERS/perplexity.sh" "hi" --image-file "$bf" --image-mime image/png
+    [ "$status" -eq 0 ]
+    grep -qF 'image_url' "$DATA_FILE"
+    grep -qF 'data:image/png;base64,QUJD' "$DATA_FILE"
+    grep -qF 'search_recency_filter' "$DATA_FILE"
+}
+
+@test "provider_vision_capable: true for gemini/openai/grok/perplexity, false for the rest" {
     source "${LIB_DIR}/providers.sh"
     provider_vision_capable gemini
     provider_vision_capable openai
-    ! provider_vision_capable grok
-    ! provider_vision_capable perplexity
+    provider_vision_capable grok
+    provider_vision_capable perplexity
     ! provider_vision_capable codex
     ! provider_vision_capable antigravity
 }


### PR DESCRIPTION
## Summary

Extends council image support to **grok** and **perplexity**. Both now analyze an attached `--image` natively instead of answering text-only.

Grok 4.x and Perplexity Sonar accept image input over their **OpenAI-compatible** `/chat/completions` endpoints, so this reuses `openai.sh`'s chat-path image block rather than inventing new plumbing.

## Changes

| File | Change |
|---|---|
| `scripts/providers/grok.sh` | Parse `--image-file` / `--image-mime` (same argv contract as `openai.sh`); when an image is present, build the user message as an OpenAI-shaped `[text, image_url]` array with a `data:<mime>;base64,<b64>` URI (read via jq `--rawfile`). Text-only path byte-identical. |
| `scripts/providers/perplexity.sh` | Same flags. User content is built **once** into `USER_CONTENT` (bare string, or `[text, image_url]` array) and injected via `--argjson` into both the recency and non-recency payload branches — avoids a 2×2 image×recency duplication and preserves `search_recency_filter` / `return_citations`. |
| `scripts/lib/providers.sh` | `provider_vision_capable()` → `gemini\|openai\|grok\|perplexity`, so `query-council.sh` routes the image to them directly. |
| `tests/providers.bats` | +3 behavioral tests (grok, perplexity, perplexity-with-recency) asserting the `image_url` data-URI lands in the real captured payload; the recency test proves it coexists with `search_recency_filter`. `provider_vision_capable` characterization updated. |
| `tests/image.bats` | The "non-vision provider" example used `perplexity` — no longer valid. Rewritten to `codex` without `OPENAI_API_KEY` (its vision sibling is then unusable, so it hits the same text-only tag path). |
| `README.md`, `docs/ARCHITECTURE.md`, `TESTING.md` | Vision-capable set now lists grok/perplexity; removed the now-false "answer text-only" lines; bumped the providers.bats count (16→19). |

Both providers use the identical OpenAI chat-completions shape:
```json
{ "type": "image_url", "image_url": { "url": "data:<mime>;base64,<b64>" } }
```

## Verification

- **shellcheck** clean on all three edited scripts.
- **bats 27/27** green (`providers.bats` + `image.bats`), independently re-run.
- Vendor docs confirm the format for **this branch's default models**, not just the newest: grok-4.20-reasoning documents `Multimodal support: Input text and images` (jpg/jpeg/png), and sonar-reasoning-pro documents image input in the same shape — so vision is correct here regardless of the separate `grok-4.5` default bump in the model-update PR.

## Notes

- **`provider_vision_capable` keys on provider name, not model** — matching the pre-existing openai/gemini design. A `GROK_MODEL` / `PERPLEXITY_MODEL` override to a non-vision model would route an image the API rejects; that's the same latent edge the existing vision providers have, not a new one.
- **`CHANGELOG.md` intentionally not edited** — its image-support entry describes a *past* release that genuinely shipped grok/perplexity as text-only. This feature earns a new entry at release time, not a retroactive rewrite.

Produced via a tiered agent workflow (Sonnet 5 research → Opus 4.8 implement + review → Fable 5 finalize) and independently verified before commit.

https://claude.ai/code/session_01NmsoctNj3zNzCiBZC7SnNG
