### PR TITLE
feat: reactive model-availability fallback with notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to claude-council are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to a `YYYY.M.BUILD` versioning scheme where `BUILD` resets each month.
 
+## Unreleased
+
+### Added
+
+- **Model fallback for API providers.** When a provider's default model is
+  unavailable for your key or region — the API answers 403/404, or a 400
+  naming the model — the council retries with a verified fallback model
+  instead of failing, and reports the substitution on three surfaces: the
+  rendered header (`grok-4.20-reasoning (grok-4.5 unavailable)`), a stderr
+  note, and the synthesis. `grok-4.5`, for example, is not currently served in
+  the EU. The verdict is cached for a day (`COUNCIL_AVAILABILITY_TTL`,
+  seconds, `0` to re-check every query) so the unavailable model isn't
+  retried on every call, and the council returns to the default automatically
+  once it becomes available. An explicit `<PROVIDER>_MODEL` opts a provider
+  out of the fallback.
+
+### Fixed
+
+- **xAI errors reported their HTTP code instead of their reason.** xAI returns
+  `.error` as a bare string rather than an object. `.error.message` on a string
+  raises a jq error rather than yielding null, and `//` does not catch a raise —
+  so the existing check read every xAI failure as "no usable message" and
+  replaced the body, printing `Error from Grok: HTTP 403` instead of *"The
+  model grok-4.5 is not available in your region."*
+- **Any OpenAI API error crashed the provider script instead of reporting it.**
+  On the `/v1/responses` path — which the default model `gpt-5.6-sol` uses —
+  the text extraction iterated `.output[]` over an error body that has no
+  `.output` key. jq exits 5, and under `set -euo pipefail` the command
+  substitution aborted the script before its error-handling block ever ran.
+  Users saw a raw jq diagnostic and exit 5 instead of a reported error.
+
 ## 2026.7.4
 
 No user-facing behavior changes. This release makes the shell linter tell the

--- a/README.md
+++ b/README.md
@@ -478,6 +478,36 @@ export COUNCIL_MAX_TOKENS=4096  # longer responses
 export COUNCIL_MAX_TOKENS=1024  # shorter, faster responses
 ```
 
+### Model fallback
+
+If a provider's default model is unavailable for your API key or region, the
+council answers with a verified fallback model instead of failing, and says so
+in the response header:
+
+```
+## 🟥 Grok - grok-4.20-reasoning (grok-4.5 unavailable)
+```
+
+| Provider | Default | Fallback |
+|---|---|---|
+| openai | `gpt-5.6-sol` | `gpt-5.5-pro` |
+| grok | `grok-4.5` | `grok-4.20-reasoning` |
+| gemini | `gemini-3.1-pro-preview` | `gemini-pro-latest` |
+| perplexity | `sonar-reasoning-pro` | `sonar-pro` |
+
+The same substitution is also noted on stderr and folded into the synthesis,
+so it's visible even in quiet mode or a headless run. Setting `<PROVIDER>_MODEL`
+explicitly disables the fallback for that provider — an explicit choice is
+respected verbatim.
+
+The verdict — "this model is unavailable for this key" — is cached for a day
+so it isn't retried on every query, and the council returns to the default
+automatically once it becomes available. This is a separate cache from the
+response cache above (`COUNCIL_CACHE_DIR` / `COUNCIL_CACHE_TTL`): it tracks
+per-model availability, not full answers. Tune it with `COUNCIL_AVAILABILITY_TTL`
+(seconds, default `86400`); set it to `0` to re-check on every query. It is
+independent of `--no-cache`, which only forces fresh *answers*.
+
 ### Reasoning Models
 
 For reasoning models from any provider, the token limit is automatically increased to 8x the base value (minimum 32768). This is because reasoning models combine internal thinking tokens and visible output tokens into a single `max_output_tokens` limit — without the bump, the model can run out mid-response.

--- a/TESTING.md
+++ b/TESTING.md
@@ -47,24 +47,25 @@ bats --verbose-run tests/cache.bats
 | `roles.bats` | 47 tests | presets, validation, prompt injection, assignment, local-council role resolution + member count |
 | `tokens.bats` | 9 tests | reasoning-model token-cap bumping, glob patterns, floor, multi-pattern |
 | `verbosity.bats` | 9 tests | brief/standard/detailed directives, fallback to standard |
-| `query-council.bats` | 19 tests | argument parsing, error cases, flags, local-council fallback hint |
+| `query-council.bats` | 26 tests | argument parsing, error cases, flags, local-council fallback hint, model-fallback wrapper (preferred-then-fallback retry, cached-verdict skip, explicit `<PROVIDER>_MODEL` opt-out, no verdict remembered when the fallback also fails), round 2 and CLI-sibling fallback carrying `model_fallback` |
 | `argmax.bats` | 4 tests | large response/prompt/debate-round-2 round-trip through final JSON (MSYS ARG_MAX marshalling guard) |
 | `fake-clis.bats` | 14 tests | fixture self-checks, codex.sh/antigravity.sh against fake binaries |
-| `format-output.bats` | 11 tests | defensive parsing: empty/missing/non-string responses, raw preservation, fallback-note rendering |
+| `format-output.bats` | 13 tests | defensive parsing: empty/missing/non-string responses, raw preservation, CLI→API fallback-note rendering, model-fallback note (preferred model named, absent when unset) |
 | `prompts.bats` | 11 tests | template loading, {{VAR}} interpolation, role-injection rendering |
 | `agent-analysis.bats` | 11 tests | validate-analysis.sh contract enforcement, schema sync |
 | `check-status.bats` | 25 tests | two-tier CLI availability, remediation strings, HTTP probe branches (401/403/500/000), rejected-key classification (Gemini/xAI answer a bad key with 400, not 401) and its false-positive guards (a typo'd model is not a bad key), transfer-failure exit codes, curl writing nothing, unusable jq, Perplexity's minimum max_tokens, `-X POST` and `--max-time` on every probe, temp-file cleanup, keys off the curl argv, ms clock |
 | `jobs.bats` | 16 tests | job store, --async lifecycle, --result/--jobs/--cancel, self-ignoring cache dir |
 | `stop-gate.bats` | 10 tests | opt-in gating, loop guards, BLOCK verdict, fail-open |
 | `theme.bats` | 24 tests | terminal theme detection, theme-aware emphasis + muted-text (faint/gray) rendering |
-| `providers.bats` | 19 tests | API provider payloads, response parsing, endpoint routing, secret/payload hygiene, vision image injection (gemini inlineData, openai input_image/image_url, grok/perplexity image_url) |
+| `providers.bats` | 25 tests | API provider payloads, response parsing, endpoint routing, secret/payload hygiene, vision image injection (gemini inlineData, openai input_image/image_url, grok/perplexity image_url), model-unavailable exit-3 classification per provider (grok 403 region block, openai/gemini/perplexity 404/400) vs. ordinary errors (401/500) still exiting 1 |
 | `image.bats` | 8 tests | --image validation (missing/bad-type/oversize), vision routing, CLI→sibling routing, non-vision text-only tag, base64 never in the cache |
 | `pane-watcher.bats` | 3 tests | standalone pane watcher: banner + response render, error notice, SetMark, watch-dir cleanup |
 | `export.bats` | 5 tests | markdown transcript export writing + formatting |
 | `release.bats` | 5 tests | release.sh version bump/commit/tag, staged-index guard, green-suite gate |
-| `retry.bats` | 6 tests | curl_with_retry backoff + status handling, curl_secret_config off-argv config file |
+| `retry.bats` | 11 tests | curl_with_retry backoff + status handling, curl_secret_config off-argv config file, ensure_error_body http_status stamping (object and string `.error`, Gemini's string `.error.status` left alone, synthesised message, 200 passthrough) |
+| `model_fallback.bats` | 28 tests | is_model_unavailable_error classifier (positive/negative fixtures from real vendor bodies), model_fallback_for pairs, verdict cache (TTL, provider+model+key scoping, corrupt/fractional-timestamp guards), model_fallback_key_hash, gated real-API test (grok-4.5's EU region block, end to end) |
 
-**Total: 367 tests** across 23 `.bats` files.
+**Total: 418 tests** across 24 `.bats` files.
 
 ### Hermetic CLI Fixture
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -126,6 +126,9 @@ INPUT:  --prompt-file <path>  the prompt; the orchestrator always uses this so a
         $1                    a literal prompt, for direct/manual invocation
 OUTPUT: stdout = AI response text
 EXIT:   0 = success, non-zero = failure (error to stderr)
+        3 = the requested model is unavailable for this key/region — the
+            orchestrator's model-fallback wrapper retries with a fallback
+            model instead of surfacing the error (see Model Fallback below)
 ```
 
 Two flavors share the interface:
@@ -194,6 +197,30 @@ curl_secret_config(header...):
   - callers pass it via `curl --config <file>` so API keys never ride the
     process argv (ps-visible) or a URL query string
 ```
+
+### Model Fallback (`scripts/lib/retry.sh`, `scripts/lib/model_fallback.sh`)
+
+```
+is_model_unavailable_error(body):        # retry.sh
+  - true only for a 403/404, or a 400 whose message names the model
+  - excludes 401/429/5xx: no other model fixes those
+  - reads .http_status, stamped onto every >=400 body by ensure_error_body
+    (handles xAI's bare-string .error as well as the usual .error.message)
+
+model_fallback_for(provider) -> model    # model_fallback.sh
+  - one verified fallback per API provider (openai, grok, gemini, perplexity)
+  - empty for CLI providers, which degrade to their API sibling instead
+
+model_unavailable_cached/remember(provider, model, key_hash):
+  - TTL-cached "unavailable" verdict, scoped to provider + preferred model + key
+  - written only once the fallback model has actually answered
+  - independent of the response cache; tunable via COUNCIL_AVAILABILITY_TTL
+```
+
+`query-council.sh`'s `run_provider_with_model_fallback` wraps a provider
+script: a preferred-model exit 3 (see Provider Scripts below), or a cached
+verdict, retries once with the fallback. The substitution is reported on the
+response header, on stderr, and folded into the synthesis prompt.
 
 ### Role System (`scripts/lib/roles.sh`)
 
@@ -410,6 +437,7 @@ claude-council/
 │       ├── hash.sh              # Portable SHA-256 helper (shasum / sha256sum)
 │       ├── jobs.sh              # Background job store
 │       ├── keys.sh              # API key resolution (XAI_API_KEY ↔ GROK_API_KEY)
+│       ├── model_fallback.sh    # Fallback model per provider + TTL-cached unavailable verdicts
 │       ├── pane-watcher.sh      # Runs in the tmux pane: streams status + rendered responses
 │       ├── prompts.sh           # Template loading + {{VAR}} interpolation
 │       ├── providers.sh         # Discovery + CLI-prefers-API policy + vendor display
@@ -448,6 +476,7 @@ claude-council/
 │   ├── image.bats               # Vision / --image routing + privacy guards
 │   ├── jobs.bats
 │   ├── keys.bats
+│   ├── model_fallback.bats      # Classifier, fallback pairs, verdict cache, gated real-API test
 │   ├── pane-watcher.bats
 │   ├── prompts.bats
 │   ├── providers.bats           # API provider payloads + secret hygiene
@@ -484,6 +513,7 @@ claude-council/
 | `COUNCIL_TIMEOUT` | 300 | Request timeout (s) |
 | `COUNCIL_CACHE_DIR` | .claude/council-cache | Cache location |
 | `COUNCIL_CACHE_TTL` | 3600 | Cache lifetime (s) |
+| `COUNCIL_AVAILABILITY_TTL` | 86400 | Model-unavailable verdict cache lifetime (s); `0` re-checks every query |
 | `COUNCIL_JOBS_DIR` | per-workspace under `$CLAUDE_PLUGIN_DATA` | Background job state location |
 | `COUNCIL_MAX_JOBS` | 20 | Terminal-status jobs kept before pruning |
 | `COUNCIL_PROMPTS_DIR` | prompts/ | Prompt template location |

--- a/prompts/synthesis.md
+++ b/prompts/synthesis.md
@@ -10,3 +10,4 @@ Calibration rules:
 - Only report divergence that changes the decision; ignore differences in wording or emphasis.
 - If all providers agree, say so plainly and keep the synthesis short.
 - If a provider returned an error or an empty/unparseable response, name it and exclude it from consensus claims.
+- If any provider's header shows that its default model was unavailable and a fallback model answered (rendered as `<model> (<preferred> unavailable)`), say so explicitly in the synthesis, naming both models — a reader comparing council members needs to know one did not answer with its usual model.

--- a/scripts/format-output.sh
+++ b/scripts/format-output.sh
@@ -23,8 +23,10 @@ fi
 source "${SCRIPT_DIR}/lib/providers.sh"
 
 # Draw header bar (markdown compatible)
-# Args: emoji provider_name model [role] [header_type] [fallback]
+# Args: emoji provider_name model [role] [header_type] [fallback] [model_fallback]
 # header_type: normal, rebuttal
+# fallback: a sibling PROVIDER answered instead (CLI→API swap)
+# model_fallback: the preferred MODEL was unavailable and a fallback model answered
 draw_header() {
     local emoji="$1"
     local provider="$2"
@@ -32,6 +34,7 @@ draw_header() {
     local role="${4:-}"
     local header_type="${5:-normal}"
     local fallback="${6:-}"
+    local model_fallback="${7:-}"
 
     # Capitalize provider name
     local provider_cap
@@ -50,6 +53,9 @@ draw_header() {
     fi
     if [[ -n "$fallback" ]] && [[ "$fallback" != "null" ]]; then
         header_text="${header_text} (fell back to ${fallback} API)"
+    fi
+    if [[ -n "$model_fallback" ]] && [[ "$model_fallback" != "null" ]]; then
+        header_text="${header_text} (${model_fallback} unavailable)"
     fi
 
     # Draw markdown header
@@ -139,10 +145,12 @@ format_output() {
             role=$(echo "$json" | jq -r ".round1[\"${provider}\"].role // empty")
             local fallback
             fallback=$(echo "$json" | jq -r ".round1[\"${provider}\"].fallback // empty")
+            local model_fallback
+            model_fallback=$(echo "$json" | jq -r ".round1[\"${provider}\"].model_fallback // empty")
             local entry
             entry=$(echo "$json" | jq -c ".round1[\"${provider}\"]")
 
-            draw_header "$emoji" "$provider" "$model" "$role" "normal" "$fallback"
+            draw_header "$emoji" "$provider" "$model" "$role" "normal" "$fallback" "$model_fallback"
             render_response "$entry"
             echo ""
         done
@@ -165,11 +173,13 @@ format_output() {
                     model=$(echo "$json" | jq -r ".round2[\"${provider}\"].model // \"unknown\"")
                     local fallback
                     fallback=$(echo "$json" | jq -r ".round2[\"${provider}\"].fallback // empty")
+                    local model_fallback
+                    model_fallback=$(echo "$json" | jq -r ".round2[\"${provider}\"].model_fallback // empty")
                     local entry
                     # A provider absent from round2 renders as an error entry
                     entry=$(echo "$json" | jq -c ".round2[\"${provider}\"] // {\"status\": \"error\"}")
 
-                    draw_header "$emoji" "$provider" "$model" "" "rebuttal" "$fallback"
+                    draw_header "$emoji" "$provider" "$model" "" "rebuttal" "$fallback" "$model_fallback"
                     render_response "$entry"
                     echo ""
                 done

--- a/scripts/lib/model_fallback.sh
+++ b/scripts/lib/model_fallback.sh
@@ -20,3 +20,59 @@ model_fallback_for() {
     done
     echo ""
 }
+
+# How long an "unavailable" verdict stays fresh. Deliberately independent of
+# COUNCIL_CACHE_TTL and of --no-cache: a regional rollout moves on the order of
+# days, and forcing fresh answers should not force a re-failed API call.
+# COUNCIL_AVAILABILITY_TTL=0 disables the cache entirely.
+COUNCIL_AVAILABILITY_TTL="${COUNCIL_AVAILABILITY_TTL:-86400}"
+
+# Short digest of a provider's API key. Availability depends on the key
+# (region and tier), not on the provider name, so verdicts are scoped to it.
+model_fallback_key_hash() {
+    local var val
+    var="$(echo "$1" | tr '[:lower:]' '[:upper:]')_API_KEY"
+    val="${!var:-}"
+    printf '%s' "$val" | sha256_hex | cut -c1-16
+}
+
+model_verdict_dir() {
+    printf '%s' "${COUNCIL_CACHE_DIR}/model-verdicts"
+}
+
+# Verdict path for provider+preferred-model+key. The model is hashed so an id
+# containing a slash (e.g. "models/x") cannot escape the directory.
+model_verdict_file() {
+    local mhash
+    mhash=$(printf '%s' "$2" | sha256_hex | cut -c1-16)
+    printf '%s/%s-%s-%s.json' "$(model_verdict_dir)" "$1" "$mhash" "$3"
+}
+
+# True (exit 0) if a fresh "unavailable" verdict exists for this provider+model+key.
+model_unavailable_cached() {
+    local file ts now age
+    file="$(model_verdict_file "$1" "$2" "$3")"
+    [[ -f "$file" ]] || return 1
+    # A truncated or hand-edited entry yields a non-numeric timestamp, and the
+    # arithmetic below would then abort the run under `set -e`. Treat any
+    # unusable timestamp as epoch 0 — infinitely stale — and re-probe.
+    ts=$(jq -r '.checked_at // 0' "$file" 2>/dev/null || echo 0)
+    [[ "$ts" =~ ^[0-9]+$ ]] || ts=0
+    now=$(date +%s)
+    age=$((now - ts))
+    [[ $age -lt $COUNCIL_AVAILABILITY_TTL ]]
+}
+
+# Record that <preferred> is unavailable for <provider> under this key. Callers
+# write this only after the fallback model has answered, so an account-level 403
+# — where the fallback fails too — cannot poison a day of runs with a wrong verdict.
+model_unavailable_remember() {
+    ensure_cache_dir
+    local dir file now
+    dir="$(model_verdict_dir)"
+    mkdir -p "$dir"
+    file="$(model_verdict_file "$1" "$2" "$3")"
+    now=$(date +%s)
+    jq -n --arg p "$1" --arg m "$2" --argjson t "$now" \
+        '{provider: $p, model: $m, checked_at: $t}' > "$file"
+}

--- a/scripts/lib/model_fallback.sh
+++ b/scripts/lib/model_fallback.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# ABOUTME: Fallback model per provider, plus a TTL cache of "unavailable" verdicts
+# ABOUTME: A verdict is recorded only once the fallback model has actually answered
+
+LIB_MODEL_FALLBACK_DIR="$(dirname "${BASH_SOURCE[0]}")"
+source "${LIB_MODEL_FALLBACK_DIR}/cache.sh"
+
+# One source of truth for the fallback map, as "provider:fallback" tokens; the
+# preferred model is whatever get_model returns, so it is not repeated here.
+# Mirrors the SHADOW_PAIRS idiom in providers.sh. Adding a provider is one token.
+# Every id below was confirmed with a real completion on 2026-07-10.
+MODEL_FALLBACKS="openai:gpt-5.5-pro grok:grok-4.20-reasoning perplexity:sonar-pro gemini:gemini-pro-latest"
+
+# The model a provider degrades to when its preferred model is unavailable.
+# Empty for CLI providers, which degrade to their API sibling instead.
+model_fallback_for() {
+    local token
+    for token in $MODEL_FALLBACKS; do
+        [[ "${token%%:*}" == "$1" ]] && { echo "${token#*:}"; return; }
+    done
+    echo ""
+}

--- a/scripts/lib/model_fallback.sh
+++ b/scripts/lib/model_fallback.sh
@@ -8,7 +8,9 @@ source "${LIB_MODEL_FALLBACK_DIR}/cache.sh"
 # One source of truth for the fallback map, as "provider:fallback" tokens; the
 # preferred model is whatever get_model returns, so it is not repeated here.
 # Mirrors the SHADOW_PAIRS idiom in providers.sh. Adding a provider is one token.
-# Every id below was confirmed with a real completion on 2026-07-10.
+# Each id is verified against the live API before it lands here: a model can be
+# listed by a provider's models endpoint and still fail a completion (gemini-2.5-pro
+# is listed by Google's, and 404s on generateContent).
 MODEL_FALLBACKS="openai:gpt-5.5-pro grok:grok-4.20-reasoning perplexity:sonar-pro gemini:gemini-pro-latest"
 
 # The model a provider degrades to when its preferred model is unavailable.

--- a/scripts/lib/retry.sh
+++ b/scripts/lib/retry.sh
@@ -42,16 +42,27 @@ retry_error_body() {
 }
 
 # Given the final HTTP code and response body (on stdin), pass the body through
-# unless it is a >=400 status with no usable .error.message — in which case
-# synthesise one carrying the HTTP code, keeping the raw body for detail.
+# unless it is a >=400 status with no usable message — in which case synthesise
+# one carrying the HTTP code, keeping the raw body for detail. Every >=400 body
+# gains a top-level .http_status so callers can classify the failure.
 ensure_error_body() {
     local code="$1" body
     body=$(cat)
     if [[ "$code" =~ ^[0-9]+$ ]] && (( code >= 400 )); then
-        if ! printf '%s' "$body" | jq -e '(.error.message // .error) | select(. != null and . != "")' >/dev/null 2>&1; then
-            jq -n --arg m "HTTP $code" --arg raw "$body" '{error: {message: $m, raw: $raw}}'
-            return
+        # `.error.message` on a string `.error` (xAI) raises a jq error rather
+        # than yielding null, and `//` does not catch an error — so branch on
+        # the type before indexing.
+        if ! printf '%s' "$body" | jq -e '
+            type == "object" and
+            ((if (.error | type) == "object" then .error.message
+              elif (.error | type) == "string" then .error
+              else null end) | . != null and . != "")' >/dev/null 2>&1; then
+            body=$(jq -n --arg m "HTTP $code" --arg raw "$body" '{error: {message: $m, raw: $raw}}')
         fi
+        # Stamped at the top level, never under .error: .error is a bare string
+        # for xAI, and Gemini's own .error.status is a string like "NOT_FOUND".
+        printf '%s' "$body" | jq --argjson c "$code" '. + {http_status: $c}'
+        return
     fi
     printf '%s' "$body"
 }

--- a/scripts/lib/retry.sh
+++ b/scripts/lib/retry.sh
@@ -132,3 +132,40 @@ curl_with_retry() {
     printf '%s' "$response" | ensure_error_body "$http_code"
     return 0
 }
+
+# True (exit 0) if a provider error body says the requested model is unavailable
+# for this key or region — the one failure a different model can fix. Auth (401),
+# rate limits (429) and 5xx are excluded: retrying them on another model wastes a
+# call and hides the real problem.
+#
+# Reads the top-level .http_status stamped by ensure_error_body. Bodies
+# synthesised by retry_error_body (timeout, network) carry no status, so a
+# transient failure never downgrades a model.
+is_model_unavailable_error() {
+    local body="$1" code msg
+    code=$(jq -r 'if type == "object" then (.http_status // empty) else empty end' <<<"$body" 2>/dev/null) || return 1
+    [[ -n "$code" ]] || return 1
+
+    case "$code" in
+        # The model is absent, or this key cannot reach it.
+        403|404) return 0 ;;
+        # A 400 is ambiguous — it covers both "no such model" and ordinary bad
+        # parameters — so only a message naming the model qualifies.
+        400) ;;
+        *) return 1 ;;
+    esac
+
+    # .error is an object for OpenAI/Gemini/Perplexity and a bare string for xAI.
+    msg=$(jq -r '
+        (if (.error | type) == "object" then (.error.message // "")
+         elif (.error | type) == "string" then .error
+         else "" end) | ascii_downcase' <<<"$body" 2>/dev/null) || return 1
+
+    # Deliberately not matching "not supported": OpenAI's 400 for an unsupported
+    # reasoning effort reads "'low' is not supported with the 'gpt-5.5-pro' model".
+    case "$msg" in
+        *"model not found"*|*"model_not_found"*|*"invalid model"*|\
+        *"does not exist"*|*"no access to model"*) return 0 ;;
+        *) return 1 ;;
+    esac
+}

--- a/scripts/lib/retry.sh
+++ b/scripts/lib/retry.sh
@@ -161,6 +161,13 @@ is_model_unavailable_error() {
          elif (.error | type) == "string" then .error
          else "" end) | ascii_downcase' <<<"$body" 2>/dev/null) || return 1
 
+    # A model-unavailable 400 always names the model; a bad-parameter or
+    # missing-resource 400 does not.
+    case "$msg" in
+        *model*) ;;
+        *) return 1 ;;
+    esac
+
     # Deliberately not matching "not supported": OpenAI's 400 for an unsupported
     # reasoning effort reads "'low' is not supported with the 'gpt-5.5-pro' model".
     case "$msg" in

--- a/scripts/providers/gemini.sh
+++ b/scripts/providers/gemini.sh
@@ -99,6 +99,7 @@ TEXT=$(echo "$RESPONSE" | jq -r '.candidates[0].content.parts[0].text // empty')
 if [[ -z "$TEXT" ]]; then
     ERROR=$(echo "$RESPONSE" | jq -r '.error.message // "Unknown error"')
     echo "Error from Gemini: $ERROR" >&2
+    is_model_unavailable_error "$RESPONSE" && exit 3
     exit 1
 fi
 

--- a/scripts/providers/grok.sh
+++ b/scripts/providers/grok.sh
@@ -109,8 +109,11 @@ RESPONSE=$(curl_with_retry -s -X POST "$ENDPOINT" \
 TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
 
 if [[ -z "$TEXT" ]]; then
-    ERROR=$(echo "$RESPONSE" | jq -r '.error.message // "Unknown error"')
+    ERROR=$(echo "$RESPONSE" | jq -r '(if (.error | type) == "object" then (.error.message // "") elif (.error | type) == "string" then .error else "" end) | select(. != "") // "Unknown error"')
     echo "Error from Grok: $ERROR" >&2
+    # Exit 3 tells query-council.sh this model is unavailable for this key or
+    # region, and that the fallback model is worth trying.
+    is_model_unavailable_error "$RESPONSE" && exit 3
     exit 1
 fi
 

--- a/scripts/providers/openai.sh
+++ b/scripts/providers/openai.sh
@@ -121,9 +121,12 @@ if [[ "$MODEL" == codex-* ]] || [[ "$MODEL" == *-codex ]] || [[ "$MODEL" == o3-*
     fi
 
     # Extract text from v1/responses format
-    # Find the message output (skip reasoning outputs) and get the text
+    # Find the message output (skip reasoning outputs) and get the text.
+    # .output[]? tolerates an error body, which carries no .output field —
+    # without it jq raises on null and the script would exit 5, not the
+    # error handling below.
     TEXT=$(echo "$RESPONSE" | jq -r '
-        [.output[] | select(.type == "message") | .content[0].text] | first // empty
+        [.output[]? | select(.type == "message") | .content[0].text] | first // empty
     ')
 else
     # Use v1/chat/completions API
@@ -184,6 +187,7 @@ if [[ -z "$TEXT" ]]; then
     else
         echo "Error from OpenAI: $ERROR" >&2
     fi
+    is_model_unavailable_error "$RESPONSE" && exit 3
     exit 1
 fi
 

--- a/scripts/providers/openai.sh
+++ b/scripts/providers/openai.sh
@@ -179,7 +179,7 @@ fi
 
 if [[ -z "$TEXT" ]]; then
     # Try multiple error paths
-    ERROR=$(echo "$RESPONSE" | jq -r '.error.message // .error // empty')
+    ERROR=$(echo "$RESPONSE" | jq -r '(if (.error | type) == "object" then (.error.message // .error.code // "") elif (.error | type) == "string" then .error else "" end) | select(. != "")')
     if [[ -z "$ERROR" ]]; then
         # Show raw response for debugging
         echo "Error from OpenAI: Unable to parse response" >&2

--- a/scripts/providers/perplexity.sh
+++ b/scripts/providers/perplexity.sh
@@ -158,6 +158,7 @@ TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
 if [[ -z "$TEXT" ]]; then
     ERROR=$(echo "$RESPONSE" | jq -r '.error.message // .error // "Unknown error"')
     echo "Error from Perplexity: $ERROR" >&2
+    is_model_unavailable_error "$RESPONSE" && exit 3
     exit 1
 fi
 

--- a/scripts/providers/perplexity.sh
+++ b/scripts/providers/perplexity.sh
@@ -156,7 +156,7 @@ fi
 TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
 
 if [[ -z "$TEXT" ]]; then
-    ERROR=$(echo "$RESPONSE" | jq -r '.error.message // .error // "Unknown error"')
+    ERROR=$(echo "$RESPONSE" | jq -r '(if (.error | type) == "object" then (.error.message // "") elif (.error | type) == "string" then .error else "" end) | select(. != "") // "Unknown error"')
     echo "Error from Perplexity: $ERROR" >&2
     is_model_unavailable_error "$RESPONSE" && exit 3
     exit 1

--- a/scripts/query-council.sh
+++ b/scripts/query-council.sh
@@ -413,7 +413,7 @@ run_provider_with_model_fallback() {
 # the original CLI error). Shared by round 1 (query_provider) and round 2.
 attempt_api_fallback() {
     local provider="$1" prompt="$2"
-    local sibling sibling_script sibling_model key cached p
+    local sibling sibling_script key cached p
     sibling=$(api_sibling "$provider")
     [[ -n "$sibling" ]] && api_key_present "$sibling" || return 0
     # Don't shadow-fall-back to a provider the user already selected — it
@@ -422,7 +422,23 @@ attempt_api_fallback() {
     for p in ${PROVIDERS[@]+"${PROVIDERS[@]}"}; do
         [[ "$p" == "$sibling" ]] && return 0
     done
-    sibling_model=$(get_model "$sibling")
+    # Resolve the sibling's effective model before its answer cache is read:
+    # this cache is separate from query_provider's, and keying it by the
+    # preferred model would mislabel a cached repeat and drop its notification.
+    local sibling_preferred sibling_fallback sibling_model sibling_mf="" sib_override
+    sibling_preferred=$(get_model "$sibling")
+    sibling_model="$sibling_preferred"
+    sibling_fallback=$(model_fallback_for "$sibling")
+    sib_override="$(echo "$sibling" | tr '[:lower:]' '[:upper:]')_MODEL"
+    if [[ -z "${!sib_override:-}" && -n "$sibling_fallback" ]]; then
+        local sib_keyhash
+        sib_keyhash=$(model_fallback_key_hash "$sibling")
+        if model_unavailable_cached "$sibling" "$sibling_preferred" "$sib_keyhash"; then
+            sibling_model="$sibling_fallback"
+            sibling_mf="$sibling_preferred"
+        fi
+    fi
+
     # Reuse a cached sibling answer instead of re-hitting the paid API on a
     # repeat run; the sibling script bypasses query_provider's own cache check.
     local resp
@@ -437,14 +453,19 @@ attempt_api_fallback() {
         if [[ -n "${IMAGE_B64_FILE:-}" ]] && provider_vision_capable "$sibling"; then
             sib_img="$IMAGE_B64_FILE"; sib_mime="$IMAGE_MIME"
         fi
-        if [[ -x "$sibling_script" ]] && resp=$(run_provider_script "$sibling_script" "$prompt" "$sib_img" "$sib_mime"); then
-            [[ "$USE_CACHE" == true ]] && cache_set "$key" "$sibling" "$sibling_model" "$prompt" "$resp"
-        else
-            return 0
-        fi
+        [[ -x "$sibling_script" ]] || return 0
+        local sib_envelope sib_rc=0
+        sib_envelope=$(run_provider_with_model_fallback "$sibling" "$sibling_script" "$prompt" "$sib_img" "$sib_mime") || sib_rc=$?
+        [[ $sib_rc -eq 0 ]] || return 0
+        resp=$(jq -r '.response' <<<"$sib_envelope")
+        sibling_model=$(jq -r '.model' <<<"$sib_envelope")
+        sibling_mf=$(jq -r '.model_fallback // empty' <<<"$sib_envelope")
+        [[ "$USE_CACHE" == true ]] && cache_set "$(cache_key "$sibling" "$sibling_model" "$prompt")" \
+            "$sibling" "$sibling_model" "$prompt" "$resp"
     fi
-    printf '%s' "$resp" | jq -Rs --arg m "$sibling_model" --arg s "$sibling" \
-        '{response: ., model: $m, fallback: $s}'
+    printf '%s' "$resp" | jq -Rs --arg m "$sibling_model" --arg s "$sibling" --arg mf "$sibling_mf" \
+        '{response: ., model: $m, fallback: $s,
+          model_fallback: (if $mf == "" then null else $mf end)}'
 }
 
 # Compose a success slot from an attempt_api_fallback object ({response, model,
@@ -808,14 +829,18 @@ if [[ "$DEBATE_MODE" == true ]]; then
 
             if [[ ! -x "$script" ]]; then
                 echo '{"status": "error", "error": "Script not found"}' > "$output_file"
-            elif response=$(run_provider_script "$script" "$debate_prompt"); then
-                printf '%s' "$response" | jq -Rs '{status: "success", response: .}' > "$output_file"
             else
-                fb_json=$(attempt_api_fallback "$provider" "$debate_prompt")
-                if [[ -n "$fb_json" ]]; then
-                    fallback_slot_json "$fb_json" "" > "$output_file"
+                envelope=$(run_provider_with_model_fallback "$provider" "$script" "$debate_prompt") && r2_rc=0 || r2_rc=$?
+                if [[ ${r2_rc:-0} -eq 0 ]]; then
+                    jq -n --argjson e "$envelope" \
+                        '{status: "success", response: $e.response, model: $e.model, model_fallback: $e.model_fallback}' > "$output_file"
                 else
-                    printf '%s' "$response" | jq -Rs '{status: "error", error: .}' > "$output_file"
+                    fb_json=$(attempt_api_fallback "$provider" "$debate_prompt")
+                    if [[ -n "$fb_json" ]]; then
+                        fallback_slot_json "$fb_json" "" > "$output_file"
+                    else
+                        printf '%s' "$envelope" | jq -Rs '{status: "error", error: .}' > "$output_file"
+                    fi
                 fi
             fi
         ) &

--- a/scripts/query-council.sh
+++ b/scripts/query-council.sh
@@ -28,6 +28,7 @@ now_ms() {
 }
 
 source "${SCRIPT_DIR}/lib/providers.sh"
+source "${SCRIPT_DIR}/lib/model_fallback.sh"
 
 usage() {
     cat >&2 << 'EOF'
@@ -333,6 +334,79 @@ run_provider_script() {
     return $rc
 }
 
+# One-line stderr notice, so a headless run — no pane, no rendered header —
+# still says why a different model answered.
+model_fallback_notice() {
+    echo "note: $2 unavailable for $1 (key/region) — answered with $3" >&2
+}
+
+# Run a provider, degrading to its fallback model when the preferred model is
+# unavailable for this key or region.
+#
+# Stdout on success (exit 0): {response, model, model_fallback}
+#   model          — the model that actually answered
+#   model_fallback — the displaced preferred model, or null
+# On failure: the provider's error text on stdout and a non-zero exit, matching
+# run_provider_script's contract, so the caller's existing error / CLI→API path
+# is unchanged.
+# Args: provider script prompt [image_file] [image_mime]
+run_provider_with_model_fallback() {
+    local provider="$1" script="$2" prompt="$3" img="${4:-}" mime="${5:-}"
+    local upper override_var preferred fallback keyhash resp rc=0
+
+    upper=$(echo "$provider" | tr '[:lower:]' '[:upper:]')
+    override_var="${upper}_MODEL"
+    preferred=$(get_model "$provider")
+    fallback=$(model_fallback_for "$provider")
+
+    # An explicit override is respected verbatim, and a provider with no
+    # configured fallback has nothing to degrade to: one plain attempt.
+    if [[ -n "${!override_var:-}" || -z "$fallback" ]]; then
+        resp=$(run_provider_script "$script" "$prompt" "$img" "$mime") || rc=$?
+        [[ $rc -eq 0 ]] || { printf '%s' "$resp"; return "$rc"; }
+        printf '%s' "$resp" | jq -Rs --arg m "$preferred" '{response: ., model: $m, model_fallback: null}'
+        return 0
+    fi
+
+    keyhash=$(model_fallback_key_hash "$provider")
+
+    # A fresh verdict means the preferred model is known-bad for this key: go
+    # straight to the fallback rather than spend a call that would fail again.
+    if model_unavailable_cached "$provider" "$preferred" "$keyhash"; then
+        model_fallback_notice "$provider" "$preferred" "$fallback"
+        resp=$(export "${override_var}=${fallback}"; run_provider_script "$script" "$prompt" "$img" "$mime") || rc=$?
+        [[ $rc -eq 0 ]] || { printf '%s' "$resp"; return "$rc"; }
+        printf '%s' "$resp" | jq -Rs --arg m "$fallback" --arg p "$preferred" \
+            '{response: ., model: $m, model_fallback: $p}'
+        return 0
+    fi
+
+    resp=$(run_provider_script "$script" "$prompt" "$img" "$mime") || rc=$?
+    if [[ $rc -eq 0 ]]; then
+        printf '%s' "$resp" | jq -Rs --arg m "$preferred" '{response: ., model: $m, model_fallback: null}'
+        return 0
+    fi
+    # Exit 3 is the providers' "this model is unavailable" signal. Any other
+    # failure — bad key, rate limit, 5xx — is not one a different model fixes.
+    if [[ $rc -ne 3 ]]; then
+        printf '%s' "$resp"
+        return "$rc"
+    fi
+
+    model_fallback_notice "$provider" "$preferred" "$fallback"
+    local fb_resp fb_rc=0
+    fb_resp=$(export "${override_var}=${fallback}"; run_provider_script "$script" "$prompt" "$img" "$mime") || fb_rc=$?
+    if [[ $fb_rc -ne 0 ]]; then
+        # The fallback failed too, so this is account-level, not model-level.
+        # Remembering it would downgrade this provider for a whole TTL.
+        printf '%s' "$fb_resp"
+        return "$fb_rc"
+    fi
+    model_unavailable_remember "$provider" "$preferred" "$keyhash"
+    printf '%s' "$fb_resp" | jq -Rs --arg m "$fallback" --arg p "$preferred" \
+        '{response: ., model: $m, model_fallback: $p}'
+}
+
 # On a CLI provider failure, attempt its API-sibling fallback. Echoes a JSON
 # object {response, model, fallback} when the sibling exists, its key is set,
 # and the sibling script succeeds; echoes nothing otherwise (caller then keeps
@@ -418,8 +492,22 @@ query_provider() {
     local output_file="$3"
     local role="${4:-}"
     local script="${PROVIDERS_DIR}/${provider}.sh"
-    local model
-    model=$(get_model "$provider")
+    local preferred fallback keyhash override_var
+    local model model_fallback=""
+    preferred=$(get_model "$provider")
+    model="$preferred"
+    fallback=$(model_fallback_for "$provider")
+    override_var="$(echo "$provider" | tr '[:lower:]' '[:upper:]')_MODEL"
+    # A known-bad preferred model must be resolved BEFORE the answer cache is
+    # read: the cache is keyed by model, and a cached fallback answer lives under
+    # the fallback's key. Resolving late would miss it and re-call the API.
+    if [[ -z "${!override_var:-}" && -n "$fallback" ]]; then
+        keyhash=$(model_fallback_key_hash "$provider")
+        if model_unavailable_cached "$provider" "$preferred" "$keyhash"; then
+            model="$fallback"
+            model_fallback="$preferred"
+        fi
+    fi
 
     # Build the final prompt (with role injection if specified)
     local final_prompt
@@ -474,8 +562,14 @@ query_provider() {
         local cached_response
         cached_response=$(cache_get "$key")
         if [[ -n "$cached_response" ]]; then
+            # A cached repeat must render exactly like the fresh answer did, or
+            # the fallback notification silently disappears on the second run.
             printf '%s' "$cached_response" | jq -Rs --arg role "$role" \
-                '{status: "success", response: ., cached: true, role: (if $role == "" then null else $role end)}' > "$output_file"
+                --arg m "$model" --arg mf "$model_fallback" \
+                '{status: "success", response: ., cached: true,
+                  role: (if $role == "" then null else $role end),
+                  model: $m,
+                  model_fallback: (if $mf == "" then null else $mf end)}' > "$output_file"
             if [[ -n "${COUNCIL_PANE_DIR:-}" ]]; then
                 pane_status_event "$COUNCIL_PANE_DIR" "$provider" cached "" "$model"
                 pane_response_write "$COUNCIL_PANE_DIR" "$provider" "$cached_response"
@@ -485,16 +579,27 @@ query_provider() {
     fi
 
     # Query provider with role-injected prompt
-    if response=$(run_provider_script "$script" "$final_prompt" "$img_file" "$img_mime"); then
+    local envelope rc=0
+    envelope=$(run_provider_with_model_fallback "$provider" "$script" "$final_prompt" "$img_file" "$img_mime") || rc=$?
+    if [[ $rc -eq 0 ]]; then
         local elapsed=$(( $(now_ms) - start_ms ))
+        # The envelope is authoritative: on a fresh discovery the wrapper fell
+        # back at query time, and only it knows which model actually answered.
+        response=$(jq -r '.response' <<<"$envelope")
+        model=$(jq -r '.model' <<<"$envelope")
+        model_fallback=$(jq -r '.model_fallback // empty' <<<"$envelope")
         response="${image_note}${response}"
         printf '%s' "$response" | jq -Rs --arg role "$role" \
-            '{status: "success", response: ., cached: false, role: (if $role == "" then null else $role end)}' > "$output_file"
+            --arg m "$model" --arg mf "$model_fallback" \
+            '{status: "success", response: ., cached: false,
+              role: (if $role == "" then null else $role end),
+              model: $m,
+              model_fallback: (if $mf == "" then null else $mf end)}' > "$output_file"
         if [[ -n "${COUNCIL_PANE_DIR:-}" ]]; then
             pane_status_event "$COUNCIL_PANE_DIR" "$provider" complete "$elapsed" "$model"
             pane_response_write "$COUNCIL_PANE_DIR" "$provider" "$response"
         fi
-        # Store in cache on success
+        # Cache under the model that answered, so the repeat run reads its own key.
         if [[ "$USE_CACHE" == true ]]; then
             local key
             key=$(cache_key "$provider" "$model" "$final_prompt")
@@ -502,7 +607,7 @@ query_provider() {
         fi
     else
         finish_with_fallback_or_error "$provider" "$final_prompt" "$output_file" \
-            "$role" "$response" "$start_ms"
+            "$role" "$envelope" "$start_ms"
     fi
 }
 

--- a/skills/deep-execution/agent-prompt-template.md
+++ b/skills/deep-execution/agent-prompt-template.md
@@ -3,6 +3,13 @@
 Fill in `{PROVIDER}`, `{SCRIPT_PATH}`, `{SCHEMA_PATH}`
 (`${CLAUDE_PLUGIN_ROOT}/schemas/agent-analysis.schema.json`), and `{QUESTION}`:
 
+Maintainer note: `schemas/agent-analysis.schema.json` has no model field, and
+the `## {EMOJI} {PROVIDER} ({MODEL})` header that `skills/deep-execution/SKILL.md`
+renders around each analysis is built by that skill, not by the subagent
+prompted below. A model-fallback re-run cannot correct that header — it keeps
+showing {PROVIDER}'s default model. The displacement is only visible in the
+analysis text.
+
 ```
 You are a council provider analyst for {PROVIDER}.
 
@@ -23,6 +30,29 @@ cat > /tmp/council-question.txt <<'COUNCIL_Q_EOF'
 COUNCIL_Q_EOF
 COUNCIL_TIMEOUT=500 bash {SCRIPT_PATH} "$(cat /tmp/council-question.txt)"
 ```
+
+If that command exits with status 3, the requested model is unavailable for
+this key or region. Do not report this as an error. Instead:
+
+1. Look up the replacement model:
+   ```bash
+   source "${CLAUDE_PLUGIN_ROOT}/scripts/lib/model_fallback.sh"
+   model_fallback_for {PROVIDER}
+   ```
+2. Re-run the same command with the fallback exported as `<PROVIDER>_MODEL` —
+   the provider's name upper-cased with `_MODEL` appended. For example, for
+   provider `grok`:
+   ```bash
+   GROK_MODEL=grok-4.20-reasoning COUNCIL_TIMEOUT=500 bash {SCRIPT_PATH} "$(cat /tmp/council-question.txt)"
+   ```
+3. If the re-run also fails, report the original error.
+4. In `unique_perspective` (Round 3), open with one sentence naming both
+   models — the one that was unavailable and the one that answered — so the
+   displacement reaches the synthesis. There is no schema field for this, so
+   prose in `unique_perspective` is the only place it can be recorded.
+
+This model-fallback re-run is separate from the Round 2 follow-up below; it
+does not set `retried`.
 
 Read the response carefully.
 
@@ -54,7 +84,9 @@ matching {SCHEMA_PATH} (schemas/agent-analysis.schema.json):
 }
 
 IMPORTANT:
-- retried is true only if you actually ran a follow-up query in Round 2; otherwise false
+- retried is true only if you actually ran a follow-up query in Round 2 to
+  address a quality gap; a Round 1 model-fallback re-run (exit 3) never sets
+  this, even if it was the only re-run you did
 - full_response must contain the complete, unedited provider response
 - Be honest in your quality assessment - "good" means genuinely useful, not just "it returned text"
 - For blind_spots, think about what a different expert perspective might critique

--- a/tests/format-output.bats
+++ b/tests/format-output.bats
@@ -107,3 +107,25 @@ envelope_with_entry() {
     [ "$status" -eq 0 ]
     [[ "$output" != *"fell back"* ]]
 }
+
+@test "format-output: model_fallback note names the unavailable preferred model" {
+    local json
+    json=$(jq -n '{
+        metadata: {quiet_mode: false, debate_mode: false},
+        round1: {grok: {status: "success", model: "grok-4.20-reasoning", response: "hi", model_fallback: "grok-4.5"}}
+    }')
+    run bash "$SCRIPT" "$json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"grok-4.20-reasoning (grok-4.5 unavailable)"* ]]
+}
+
+@test "format-output: model_fallback note absent when field is not set" {
+    local json
+    json=$(jq -n '{
+        metadata: {quiet_mode: false, debate_mode: false},
+        round1: {grok: {status: "success", model: "grok-4.5", response: "hi"}}
+    }')
+    run bash "$SCRIPT" "$json"
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"unavailable"* ]]
+}

--- a/tests/model_fallback.bats
+++ b/tests/model_fallback.bats
@@ -135,3 +135,50 @@ mf() {
     mf 'model_fallback_for nosuchprovider'
     [ -z "$output" ]
 }
+
+# ============================================================================
+# Verdict cache — remember "unavailable" for a provider+model+key, with a TTL
+# ============================================================================
+
+@test "verdict cache: an unremembered verdict is not cached" {
+    mf 'model_unavailable_cached grok grok-4.5 abc123'
+    [ "$status" -ne 0 ]
+}
+
+@test "verdict cache: a remembered verdict reads back fresh" {
+    mf 'model_unavailable_remember grok grok-4.5 abc123; model_unavailable_cached grok grok-4.5 abc123'
+    [ "$status" -eq 0 ]
+}
+
+@test "verdict cache: the verdict is scoped to the model" {
+    mf 'model_unavailable_remember grok grok-4.5 abc123; model_unavailable_cached grok grok-4.3 abc123'
+    [ "$status" -ne 0 ]
+}
+
+@test "verdict cache: the verdict is scoped to the key" {
+    # A different-region key must not inherit the prior key's verdict.
+    mf 'model_unavailable_remember grok grok-4.5 abc123; model_unavailable_cached grok grok-4.5 def456'
+    [ "$status" -ne 0 ]
+}
+
+@test "verdict cache: a verdict older than the TTL is stale" {
+    mf 'model_unavailable_remember grok grok-4.5 abc123
+        COUNCIL_AVAILABILITY_TTL=0 model_unavailable_cached grok grok-4.5 abc123'
+    [ "$status" -ne 0 ]
+}
+
+@test "verdict cache: a truncated entry is treated as stale, not fatal" {
+    # An unparseable timestamp must not abort the run under set -e.
+    mf 'model_unavailable_remember grok grok-4.5 abc123
+        f=$(model_verdict_file grok grok-4.5 abc123)
+        printf "garbage" > "$f"
+        model_unavailable_cached grok grok-4.5 abc123'
+    [ "$status" -ne 0 ]
+}
+
+@test "model_fallback_key_hash: scopes to the provider's key, not its name" {
+    mf 'GROK_API_KEY=one; a=$(model_fallback_key_hash grok)
+        GROK_API_KEY=two; b=$(model_fallback_key_hash grok)
+        [[ "$a" != "$b" ]]'
+    [ "$status" -eq 0 ]
+}

--- a/tests/model_fallback.bats
+++ b/tests/model_fallback.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# ABOUTME: Classifier + fallback-pair + verdict-cache tests for reactive model fallback
+# ABOUTME: Bodies are real vendor responses captured live; verdicts come from vendor semantics
+
+load test_helper
+bats_require_minimum_version 1.5.0
+
+RETRY_LIB="${LIB_DIR}/retry.sh"
+
+# Classify a body through a stamped ensure_error_body, exactly as curl_with_retry does.
+classify() {
+    run env bash -c "
+        set -euo pipefail
+        source '${RETRY_LIB}'
+        body=\$(printf '%s' '$2' | ensure_error_body '$1')
+        is_model_unavailable_error \"\$body\"
+    "
+}
+
+# --- positives: a different model would help -------------------------------
+
+@test "classifier: xAI 403 region block is model-unavailable" {
+    classify 403 '{"code":"permission-denied","error":"The model grok-4.5 is not available in your region."}'
+    [ "$status" -eq 0 ]
+}
+
+@test "classifier: xAI 400 model-not-found is model-unavailable" {
+    classify 400 '{"code":"invalid-argument","error":"Model not found: grok-does-not-exist-9"}'
+    [ "$status" -eq 0 ]
+}
+
+@test "classifier: OpenAI 404 model_not_found is model-unavailable" {
+    classify 404 '{"error":{"message":"The model gpt-does-not-exist-9 does not exist or you do not have access to it.","code":"model_not_found"}}'
+    [ "$status" -eq 0 ]
+}
+
+@test "classifier: Perplexity 400 invalid model is model-unavailable" {
+    classify 400 '{"error":{"message":"Invalid model \"sonar-does-not-exist-9\". Permitted models can be found in the documentation.","type":"invalid_model","code":400}}'
+    [ "$status" -eq 0 ]
+}
+
+@test "classifier: Gemini 404 NOT_FOUND is model-unavailable" {
+    classify 404 '{"error":{"code":404,"message":"models/gemini-does-not-exist-9 is not found for API version v1beta.","status":"NOT_FOUND"}}'
+    [ "$status" -eq 0 ]
+}
+
+# --- negatives: a different model would NOT help ---------------------------
+
+@test "classifier: OpenAI 401 bad key is not model-unavailable" {
+    classify 401 '{"error":{"message":"Incorrect API key provided.","code":"invalid_api_key"}}'
+    [ "$status" -ne 0 ]
+}
+
+@test "classifier: a 400 unsupported reasoning effort is not model-unavailable" {
+    # The message names the model and says "is not supported" — it must not match.
+    classify 400 '{"error":{"message":"Unsupported value: \"low\" is not supported with the \"gpt-5.5-pro\" model.","param":"reasoning.effort","code":"unsupported_value"}}'
+    [ "$status" -ne 0 ]
+}
+
+@test "classifier: 429 rate limit is not model-unavailable" {
+    classify 429 '{"error":{"message":"Rate limit reached."}}'
+    [ "$status" -ne 0 ]
+}
+
+@test "classifier: 500 server error is not model-unavailable" {
+    classify 500 '{"error":{"message":"Internal server error."}}'
+    [ "$status" -ne 0 ]
+}
+
+@test "classifier: a synthesised network/timeout body has no status and is not model-unavailable" {
+    run env bash -c "
+        set -euo pipefail
+        source '${RETRY_LIB}'
+        body=\$(retry_error_body 'Request timed out after 300 seconds')
+        is_model_unavailable_error \"\$body\"
+    "
+    [ "$status" -ne 0 ]
+}
+
+@test "classifier: a 200 success body is not model-unavailable" {
+    classify 200 '{"choices":[{"message":{"content":"hi"}}]}'
+    [ "$status" -ne 0 ]
+}

--- a/tests/model_fallback.bats
+++ b/tests/model_fallback.bats
@@ -198,7 +198,10 @@ mf() {
         printf "{\"checked_at\":1.5}" > "$f"
         model_unavailable_cached grok grok-4.5 abc123'
     [ "$status" -eq 1 ]
-    [[ "$output" != *"arithmetic"* ]]
+    # Assert the absence of any diagnostic rather than its wording: bash routes
+    # arithmetic errors through gettext, so matching the English text would stop
+    # detecting an unguarded leak under a translated locale.
+    [ -z "$output" ]
 }
 
 @test "model_fallback_key_hash: scopes to the provider's key, not its name" {

--- a/tests/model_fallback.bats
+++ b/tests/model_fallback.bats
@@ -142,7 +142,7 @@ mf() {
 
 @test "verdict cache: an unremembered verdict is not cached" {
     mf 'model_unavailable_cached grok grok-4.5 abc123'
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 1 ]
 }
 
 @test "verdict cache: a remembered verdict reads back fresh" {
@@ -152,19 +152,19 @@ mf() {
 
 @test "verdict cache: the verdict is scoped to the model" {
     mf 'model_unavailable_remember grok grok-4.5 abc123; model_unavailable_cached grok grok-4.3 abc123'
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 1 ]
 }
 
 @test "verdict cache: the verdict is scoped to the key" {
     # A different-region key must not inherit the prior key's verdict.
     mf 'model_unavailable_remember grok grok-4.5 abc123; model_unavailable_cached grok grok-4.5 def456'
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 1 ]
 }
 
 @test "verdict cache: a verdict older than the TTL is stale" {
     mf 'model_unavailable_remember grok grok-4.5 abc123
         COUNCIL_AVAILABILITY_TTL=0 model_unavailable_cached grok grok-4.5 abc123'
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 1 ]
 }
 
 @test "verdict cache: a truncated entry is treated as stale, not fatal" {
@@ -173,7 +173,32 @@ mf() {
         f=$(model_verdict_file grok grok-4.5 abc123)
         printf "garbage" > "$f"
         model_unavailable_cached grok grok-4.5 abc123'
-    [ "$status" -ne 0 ]
+    [ "$status" -eq 1 ]
+}
+
+@test "verdict cache: a non-numeric timestamp is stale, and does not abort the run" {
+    mf 'model_unavailable_remember grok grok-4.5 abc123
+        f=$(model_verdict_file grok grok-4.5 abc123)
+        printf "{\"checked_at\":\"notanumber\"}" > "$f"
+        model_unavailable_cached grok grok-4.5 abc123 || true
+        echo SURVIVED'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *SURVIVED* ]]
+}
+
+@test "verdict cache: a fractional timestamp is stale, without leaking a shell arithmetic error" {
+    # Unlike a bare word (which bash treats as an unset variable and, under
+    # nounset, aborts the whole run), a fractional literal fails bash's
+    # arithmetic parser instead: "invalid arithmetic operator". That parse
+    # error does not abort the run, but without the guard it still aborts the
+    # function before the TTL check runs, and prints the parser's diagnostic.
+    # Guarded, the verdict is still correctly stale (status 1) but silently so.
+    mf 'model_unavailable_remember grok grok-4.5 abc123
+        f=$(model_verdict_file grok grok-4.5 abc123)
+        printf "{\"checked_at\":1.5}" > "$f"
+        model_unavailable_cached grok grok-4.5 abc123'
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"arithmetic"* ]]
 }
 
 @test "model_fallback_key_hash: scopes to the provider's key, not its name" {

--- a/tests/model_fallback.bats
+++ b/tests/model_fallback.bats
@@ -81,3 +81,23 @@ classify() {
     classify 200 '{"choices":[{"message":{"content":"hi"}}]}'
     [ "$status" -ne 0 ]
 }
+
+@test "classifier: a 400 thread-not-found message is not model-unavailable" {
+    classify 400 '{"error":{"message":"Thread thread_abc123 does not exist."}}'
+    [ "$status" -ne 0 ]
+}
+
+@test "classifier: a 400 file-not-found message is not model-unavailable" {
+    classify 400 '{"error":{"message":"The requested file file-xyz does not exist or you do not have access to it."}}'
+    [ "$status" -ne 0 ]
+}
+
+@test "classifier: a bare JSON array body is not model-unavailable" {
+    classify 400 '[1,2,3]'
+    [ "$status" -ne 0 ]
+}
+
+@test "classifier: a 400 bare-string error not naming a model is not model-unavailable" {
+    classify 400 '{"error":"Invalid request: temperature must be between 0 and 2"}'
+    [ "$status" -ne 0 ]
+}

--- a/tests/model_fallback.bats
+++ b/tests/model_fallback.bats
@@ -210,3 +210,31 @@ mf() {
         [[ "$a" != "$b" ]]'
     [ "$status" -eq 0 ]
 }
+
+# ============================================================================
+# Real API — skipped unless a key is present
+# ============================================================================
+
+# grok-4.5 is genuinely HTTP 403 in the EU today, so this is the one test in
+# the suite that exercises the whole path with no mocks: real 403 from xAI,
+# real classification, real fallback retry, real answer. It earns its keep by
+# catching a regression the classifier fixtures cannot — e.g. xAI changing its
+# error shape in a way that still satisfies the captured-body tests above but
+# breaks against the live API.
+@test "real xAI: grok-4.5 is classified and answered by the fallback model" {
+    [[ -n "${XAI_API_KEY:-}${GROK_API_KEY:-}" ]] || skip "no xAI key present"
+    run --separate-stderr env COUNCIL_CACHE_DIR="$TEST_CACHE_DIR" COUNCIL_MAX_TOKENS=256 \
+        bash "${SCRIPTS_DIR}/query-council.sh" \
+        --providers=grok --no-pane --no-auto-context --no-cache "Reply with exactly the word: OK"
+    [ "$status" -eq 0 ]
+    # Either grok-4.5 rolled out here (then no fallback), or it did not and the
+    # fallback answered. Both are correct; a hard error is not. The assertion
+    # must not fail merely because grok-4.5 started working after the EU rollout.
+    local model
+    model=$(jq -r '.round1.grok.model' <<<"$output")
+    [[ "$model" == "grok-4.5" || "$model" == "grok-4.20-reasoning" ]]
+    [ "$(jq -r '.round1.grok.status' <<<"$output")" = "success" ]
+    if [[ "$model" == "grok-4.20-reasoning" ]]; then
+        [ "$(jq -r '.round1.grok.model_fallback' <<<"$output")" = "grok-4.5" ]
+    fi
+}

--- a/tests/model_fallback.bats
+++ b/tests/model_fallback.bats
@@ -101,3 +101,37 @@ classify() {
     classify 400 '{"error":"Invalid request: temperature must be between 0 and 2"}'
     [ "$status" -ne 0 ]
 }
+
+# ============================================================================
+# model_fallback_for — the preferred→fallback map
+# ============================================================================
+
+MF_LIB="${LIB_DIR}/model_fallback.sh"
+
+mf() {
+    run env bash -c "set -euo pipefail; source '${MF_LIB}'; $*"
+}
+
+@test "model_fallback_for: each API provider has its verified fallback" {
+    mf 'model_fallback_for openai'
+    [ "$output" = "gpt-5.5-pro" ]
+    mf 'model_fallback_for grok'
+    [ "$output" = "grok-4.20-reasoning" ]
+    mf 'model_fallback_for perplexity'
+    [ "$output" = "sonar-pro" ]
+    mf 'model_fallback_for gemini'
+    [ "$output" = "gemini-pro-latest" ]
+}
+
+@test "model_fallback_for: a CLI provider has no fallback of its own" {
+    # codex/antigravity degrade to their API sibling, which then gets model fallback.
+    mf 'model_fallback_for codex'
+    [ -z "$output" ]
+    mf 'model_fallback_for antigravity'
+    [ -z "$output" ]
+}
+
+@test "model_fallback_for: an unknown provider has no fallback" {
+    mf 'model_fallback_for nosuchprovider'
+    [ -z "$output" ]
+}

--- a/tests/providers.bats
+++ b/tests/providers.bats
@@ -243,3 +243,43 @@ run_provider() {
     ! provider_vision_capable codex
     ! provider_vision_capable antigravity
 }
+
+# ---- model-unavailable signalling: exit 3, not exit 1 ----
+
+@test "grok: a 403 region block exits 3" {
+    # Real xAI shape: .error is a bare string, .code sits at the top level.
+    FAKE_BODY='{"code":"permission-denied","error":"The model grok-4.5 is not available in your region."}' FAKE_HTTP=403
+    run_provider grok.sh "hi" XAI_API_KEY=k
+    [ "$status" -eq 3 ]
+    [[ "$stderr" == *"not available in your region"* ]]
+}
+
+@test "grok: a 401 bad key still exits 1" {
+    FAKE_BODY='{"code":"unauthenticated","error":"Incorrect API key provided."}' FAKE_HTTP=401
+    run_provider grok.sh "hi" XAI_API_KEY=k
+    [ "$status" -eq 1 ]
+}
+
+@test "openai: a 404 model_not_found exits 3" {
+    FAKE_BODY='{"error":{"message":"The model does not exist or you do not have access to it.","code":"model_not_found"}}' FAKE_HTTP=404
+    run_provider openai.sh "hi" OPENAI_API_KEY=k
+    [ "$status" -eq 3 ]
+}
+
+@test "gemini: a 404 NOT_FOUND exits 3" {
+    FAKE_BODY='{"error":{"code":404,"message":"models/x is not found for API version v1beta.","status":"NOT_FOUND"}}' FAKE_HTTP=404
+    run_provider gemini.sh "hi" GEMINI_API_KEY=k
+    [ "$status" -eq 3 ]
+}
+
+@test "perplexity: a 400 invalid model exits 3" {
+    FAKE_BODY='{"error":{"message":"Invalid model '\''x'\''.","type":"invalid_model","code":400}}' FAKE_HTTP=400
+    run_provider perplexity.sh "hi" PERPLEXITY_API_KEY=k
+    [ "$status" -eq 3 ]
+}
+
+@test "perplexity: a 500 server error still exits 1" {
+    FAKE_BODY='{"error":{"message":"Internal server error."}}' FAKE_HTTP=500
+    run_provider perplexity.sh "hi" PERPLEXITY_API_KEY=k COUNCIL_MAX_RETRIES=0
+    [ "$status" -eq 1 ]
+}

--- a/tests/providers.bats
+++ b/tests/providers.bats
@@ -283,3 +283,20 @@ run_provider() {
     run_provider perplexity.sh "hi" PERPLEXITY_API_KEY=k COUNCIL_MAX_RETRIES=0
     [ "$status" -eq 1 ]
 }
+
+@test "openai: a bare-string .error on a 502 does not crash the extractor" {
+    # A gateway/proxy body can carry .error as a bare string rather than an
+    # object; .error.message on a string raises a jq error that // cannot
+    # catch, and that would abort the script before is_model_unavailable_error runs.
+    FAKE_BODY='{"error":"upstream gateway error"}' FAKE_HTTP=502
+    run_provider openai.sh "hi" OPENAI_API_KEY=k COUNCIL_MAX_RETRIES=0
+    [ "$status" -eq 1 ]
+    [[ "$stderr" == *"upstream gateway error"* ]]
+}
+
+@test "perplexity: a bare-string .error on a 502 does not crash the extractor" {
+    FAKE_BODY='{"error":"upstream gateway error"}' FAKE_HTTP=502
+    run_provider perplexity.sh "hi" PERPLEXITY_API_KEY=k COUNCIL_MAX_RETRIES=0
+    [ "$status" -eq 1 ]
+    [[ "$stderr" == *"upstream gateway error"* ]]
+}

--- a/tests/query-council.bats
+++ b/tests/query-council.bats
@@ -318,3 +318,32 @@ EOF
     # A poisoned verdict would silently downgrade grok for a day.
     [ ! -d "${TEST_CACHE_DIR}/model-verdicts" ] || [ -z "$(ls -A "${TEST_CACHE_DIR}/model-verdicts")" ]
 }
+
+@test "round2: the rebuttal slot carries the fallback model and the displaced one" {
+    export GROK_API_KEY=k
+    write_model_aware_stub grok grok-4.5
+    run --separate-stderr env PROVIDERS_DIR="$STUB_DIR" COUNCIL_CACHE_DIR="$TEST_CACHE_DIR" \
+        bash "$SCRIPT" --providers=grok --debate --no-pane --no-auto-context --no-cache "q"
+    [ "$status" -eq 0 ]
+    assert_json_eq "$output" '.round2.grok.model' 'grok-4.20-reasoning'
+    assert_json_eq "$output" '.round2.grok.model_fallback' 'grok-4.5'
+}
+
+@test "sibling: a CLI provider's API sibling reports its own model fallback" {
+    # codex is unusable; its sibling openai answers, and openai's preferred model
+    # is itself unavailable, so the slot must name both fallbacks.
+    export OPENAI_API_KEY=k
+    write_model_aware_stub openai gpt-5.6-sol
+    cat > "$STUB_DIR/codex.sh" <<'EOF'
+#!/bin/bash
+echo "codex is broken" >&2
+exit 1
+EOF
+    chmod +x "$STUB_DIR/codex.sh"
+    run --separate-stderr env PROVIDERS_DIR="$STUB_DIR" COUNCIL_CACHE_DIR="$TEST_CACHE_DIR" \
+        bash "$SCRIPT" --providers=codex --no-pane --no-auto-context --no-cache "q"
+    [ "$status" -eq 0 ]
+    assert_json_eq "$output" '.round1.codex.fallback' 'openai'
+    assert_json_eq "$output" '.round1.codex.model' 'gpt-5.5-pro'
+    assert_json_eq "$output" '.round1.codex.model_fallback' 'gpt-5.6-sol'
+}

--- a/tests/query-council.bats
+++ b/tests/query-council.bats
@@ -233,3 +233,88 @@ run_council() {
     [[ "$r2" == *"You are GEMINI."* ]]
     [[ "$r2" == *"[GEMINI'S RESPONSE]"* ]]
 }
+
+# ============================================================================
+# run_provider_with_model_fallback
+# ============================================================================
+
+# A fake provider that exits 3 for the preferred model and 0 for the fallback,
+# reading the model from the same env var the real scripts read.
+write_model_aware_stub() {
+    local name="$1" preferred="$2"
+    cat > "$STUB_DIR/${name}.sh" <<EOF
+#!/bin/bash
+model="\${$(echo "$name" | tr '[:lower:]' '[:upper:]')_MODEL:-${preferred}}"
+echo "\$model" >> "${CALLS_LOG}"
+if [[ "\$model" == "${preferred}" ]]; then
+    echo "Error from ${name}: model unavailable" >&2
+    exit 3
+fi
+printf 'ANSWER-FROM-%s\n' "\$model"
+EOF
+    chmod +x "$STUB_DIR/${name}.sh"
+}
+
+# The wrapper is exercised through the real query-council.sh rather than sourced
+# in isolation: it depends on TEMP_DIR, PROVIDERS_DIR and the pane globals that
+# the script sets up, and driving the script proves the whole path.
+
+@test "wrapper: exit 3 on the preferred model retries with the fallback" {
+    export GROK_API_KEY=k
+    write_model_aware_stub grok grok-4.5
+    run --separate-stderr env PROVIDERS_DIR="$STUB_DIR" COUNCIL_CACHE_DIR="$TEST_CACHE_DIR" \
+        bash "$SCRIPT" --providers=grok --no-pane --no-auto-context --no-cache "q"
+    [ "$status" -eq 0 ]
+    assert_json_eq "$output" '.round1.grok.model' 'grok-4.20-reasoning'
+    assert_json_eq "$output" '.round1.grok.model_fallback' 'grok-4.5'
+    [[ "$stderr" == *"grok-4.5 unavailable"* ]]
+}
+
+@test "wrapper: the preferred model is tried first, then the fallback" {
+    export GROK_API_KEY=k
+    write_model_aware_stub grok grok-4.5
+    run --separate-stderr env PROVIDERS_DIR="$STUB_DIR" COUNCIL_CACHE_DIR="$TEST_CACHE_DIR" \
+        bash "$SCRIPT" --providers=grok --no-pane --no-auto-context --no-cache "q"
+    [ "$status" -eq 0 ]
+    [ "$(sed -n 1p "$CALLS_LOG")" = "grok-4.5" ]
+    [ "$(sed -n 2p "$CALLS_LOG")" = "grok-4.20-reasoning" ]
+}
+
+@test "wrapper: a cached verdict skips the known-bad preferred model" {
+    export GROK_API_KEY=k
+    write_model_aware_stub grok grok-4.5
+    # First run discovers and remembers the verdict.
+    env PROVIDERS_DIR="$STUB_DIR" COUNCIL_CACHE_DIR="$TEST_CACHE_DIR" \
+        bash "$SCRIPT" --providers=grok --no-pane --no-auto-context --no-cache "q" >/dev/null 2>&1
+    : > "$CALLS_LOG"
+    # Second run must go straight to the fallback: exactly one invocation.
+    env PROVIDERS_DIR="$STUB_DIR" COUNCIL_CACHE_DIR="$TEST_CACHE_DIR" \
+        bash "$SCRIPT" --providers=grok --no-pane --no-auto-context --no-cache "q" >/dev/null 2>&1
+    [ "$(grep -c . "$CALLS_LOG")" -eq 1 ]
+    [ "$(sed -n 1p "$CALLS_LOG")" = "grok-4.20-reasoning" ]
+}
+
+@test "wrapper: an explicit GROK_MODEL override never falls back" {
+    export GROK_API_KEY=k GROK_MODEL=grok-4.5
+    write_model_aware_stub grok grok-4.5
+    run --separate-stderr env PROVIDERS_DIR="$STUB_DIR" COUNCIL_CACHE_DIR="$TEST_CACHE_DIR" \
+        bash "$SCRIPT" --providers=grok --no-pane --no-auto-context --no-cache "q"
+    # The stub exits 3; with an override there is no fallback, so it is an error.
+    assert_json_eq "$output" '.round1.grok.status' 'error'
+    [ "$(grep -c . "$CALLS_LOG")" -eq 1 ]
+}
+
+@test "wrapper: when the fallback also fails, no verdict is remembered" {
+    export GROK_API_KEY=k
+    # Both models fail: an account-level block, not a model-level one.
+    cat > "$STUB_DIR/grok.sh" <<'EOF'
+#!/bin/bash
+echo "Error from grok: model unavailable" >&2
+exit 3
+EOF
+    chmod +x "$STUB_DIR/grok.sh"
+    env PROVIDERS_DIR="$STUB_DIR" COUNCIL_CACHE_DIR="$TEST_CACHE_DIR" \
+        bash "$SCRIPT" --providers=grok --no-pane --no-auto-context --no-cache "q" >/dev/null 2>&1 || true
+    # A poisoned verdict would silently downgrade grok for a day.
+    [ ! -d "${TEST_CACHE_DIR}/model-verdicts" ] || [ -z "$(ls -A "${TEST_CACHE_DIR}/model-verdicts")" ]
+}

--- a/tests/retry.bats
+++ b/tests/retry.bats
@@ -136,3 +136,51 @@ run_retry() {
     [ "$body" = "hello world" ]
     [ "$(cat "$COUNT_FILE")" -eq 1 ]
 }
+
+# ============================================================================
+# ensure_error_body — status stamping and vendor body shapes
+# ============================================================================
+
+ensure_body() {
+    run env bash -c "
+        set -euo pipefail
+        source '${RETRY_LIB}'
+        printf '%s' '$2' | ensure_error_body '$1'
+    "
+}
+
+@test "ensure_error_body: stamps http_status on an object-.error body" {
+    ensure_body 404 '{"error":{"message":"nope","code":"model_not_found"}}'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.http_status' <<<"$output")" = "404" ]
+    [ "$(jq -r '.error.message' <<<"$output")" = "nope" ]
+}
+
+@test "ensure_error_body: a string .error survives as the message" {
+    ensure_body 403 '{"code":"permission-denied","error":"The model grok-4.5 is not available in your region."}'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.http_status' <<<"$output")" = "403" ]
+    [ "$(jq -r '.error' <<<"$output")" = "The model grok-4.5 is not available in your region." ]
+}
+
+@test "ensure_error_body: does not clobber Gemini's string .error.status" {
+    ensure_body 404 '{"error":{"code":404,"message":"not found","status":"NOT_FOUND"}}'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.error.status' <<<"$output")" = "NOT_FOUND" ]
+    [ "$(jq -r '.http_status' <<<"$output")" = "404" ]
+}
+
+@test "ensure_error_body: a body with no usable message is synthesised and stamped" {
+    ensure_body 500 'not json at all'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.error.message' <<<"$output")" = "HTTP 500" ]
+    [ "$(jq -r '.error.raw' <<<"$output")" = "not json at all" ]
+    [ "$(jq -r '.http_status' <<<"$output")" = "500" ]
+}
+
+@test "ensure_error_body: a 200 body is passed through untouched" {
+    ensure_body 200 '{"choices":[{"message":{"content":"hi"}}]}'
+    [ "$status" -eq 0 ]
+    [ "$(jq -r '.http_status // "absent"' <<<"$output")" = "absent" ]
+    [ "$(jq -r '.choices[0].message.content' <<<"$output")" = "hi" ]
+}


### PR DESCRIPTION
## What

An API council member whose default model is unavailable for your key or region now answers with a verified fallback model instead of hard-failing, and tells you it happened.

The motivating case: `grok-4.5` returns **HTTP 403** in the EU ("not available in your region"), while `check-status` — which probes `/v1/models`, never a completion — shows the provider green. Before this branch, that council member returned a hard error. Now it answers with `grok-4.20-reasoning` and the header reads `grok-4.20-reasoning (grok-4.5 unavailable)`.

## Approach: reactive, not probe-based

Each provider classifies its own error body and `exit 3`s on "model unavailable". `query-council.sh` catches exit 3 and re-runs that provider with `<PROVIDER>_MODEL=<fallback>`. This covers every provider — including Perplexity, which has no `/v1/models` endpoint — and catches the "listed-but-403s" case a probe can't. (`gemini-2.5-pro` is listed by Google's models endpoint yet 404s on `generateContent`, which is exactly why probing was rejected.)

## Fallback pairs

Every id confirmed with a real API completion.

| Provider | Default | Fallback |
|---|---|---|
| openai | `gpt-5.6-sol` | `gpt-5.5-pro` |
| grok | `grok-4.5` | `grok-4.20-reasoning` |
| gemini | `gemini-3.1-pro-preview` | `gemini-pro-latest` |
| perplexity | `sonar-reasoning-pro` | `sonar-pro` |

Setting `<PROVIDER>_MODEL` explicitly disables the fallback for that provider.

## Notification — three surfaces

1. **Header** — `grok-4.20-reasoning (grok-4.5 unavailable)`
2. **stderr** — `note: grok-4.5 unavailable for grok (key/region) — answered with grok-4.20-reasoning`
3. **Synthesis** — the Claude-authored synthesis names any provider that answered on a fallback

Deep mode (`--agents`) retries on exit 3 and records the displacement in its analysis prose.

## Self-healing

The "unavailable" verdict is cached per provider + model + key-hash for `COUNCIL_AVAILABILITY_TTL` seconds (default 86400), so the known-bad model isn't retried on every query. Once the model becomes available (e.g. an EU rollout), the council returns to the default automatically within the TTL. The verdict is written **only after the fallback model actually answers**, so an account-level 403 — where the fallback fails too — can't poison a day of runs.

## Two pre-existing bugs fixed along the way

- **xAI errors reported their HTTP code, not their reason.** xAI returns `.error` as a bare string; `.error.message` on a string *raises* a jq error, which `//` doesn't catch, so the check read "no message" and replaced the body — every xAI failure printed `Error from Grok: HTTP 403` instead of the real reason.
- **Any OpenAI API error crashed the provider script.** On `/v1/responses` (the default model's path), the text extraction iterated `.output[]` over an error body with no `.output` key → jq exit 5 → `set -euo pipefail` aborted the script before its error handler ran.

## Testing

- 420 bats tests pass; shellcheck clean; `claude plugin validate` passes.
- Classifier and wrapper are hermetic (fake curl / fake providers, no network).
- One presence-gated **real-API** test exercises the whole path against live xAI — real 403 → classify → fall back → answer — and stays honest after the EU rollout (asserts `grok-4.5` OR `grok-4.20-reasoning`, only requiring the note when the fallback answered).
- Verified live end to end: cold cache falls back and notifies; a cached repeat preserves the notification; a warm verdict skips the known-bad model on a new prompt; `GROK_MODEL=grok-4.5` disables the fallback and surfaces the real region message.

https://claude.ai/code/session_01TRTG7Mjba4BbxTycQfhf2W
