### PR TITLE
feat: add grok-cli provider (xAI Grok CLI, subscription auth)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-council",
   "version": "2026.7.5",
-  "description": "Consult multiple AI coding agents (Gemini, OpenAI, Grok, Perplexity, plus codex and antigravity CLIs when installed) to get diverse perspectives on coding problems",
+  "description": "Consult multiple AI coding agents (Gemini, OpenAI, Grok, Perplexity, plus codex, antigravity, and grok CLIs when installed) to get diverse perspectives on coding problems",
   "author": {
     "name": "hex",
     "url": "https://github.com/hex"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ to a `YYYY.M.BUILD` versioning scheme where `BUILD` resets each month.
   council with no `XAI_API_KEY` and no per-call cost, the same way `codex` and
   `antigravity` already do. It shadows the `grok` API provider (listing both,
   e.g. `--providers=grok,grok-cli`, runs them side by side), pins grok's
-  built-in `read-only` sandbox as defense-in-depth, and defaults to
-  `grok-composer-2.5-fast` (override with `GROK_CLI_MODEL`). Because it is a
+  built-in `read-only` sandbox as defense-in-depth, and defaults to the grok
+  CLI's own default model unless `GROK_CLI_MODEL` is set. Because it is a
   CLI, an image query routes to its `grok` API sibling when a key is present,
   and answers text-only otherwise.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,20 @@ All notable changes to claude-council are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to a `YYYY.M.BUILD` versioning scheme where `BUILD` resets each month.
 
-## 2026.7.5
+## Unreleased
+
+### Added
+
+- **`grok-cli` provider.** Drives xAI's Grok CLI (`grok`) in headless
+  single-turn mode (`grok -p ... --output-format plain`), gated on the binary
+  being on PATH rather than an API key — so a Grok CLI subscription answers the
+  council with no `XAI_API_KEY` and no per-call cost, the same way `codex` and
+  `antigravity` already do. It shadows the `grok` API provider (listing both,
+  e.g. `--providers=grok,grok-cli`, runs them side by side), pins grok's
+  built-in `read-only` sandbox as defense-in-depth, and defaults to
+  `grok-composer-2.5-fast` (override with `GROK_CLI_MODEL`). Because it is a
+  CLI, an image query routes to its `grok` API sibling when a key is present,
+  and answers text-only otherwise.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A Claude Code plugin that consults multiple AI coding agents in parallel and sho
 
 # 2. Configure at least one provider — any of these works:
 export OPENAI_API_KEY="..."         # or GEMINI_API_KEY, XAI_API_KEY, PERPLEXITY_API_KEY
-                                    # OR install the codex / antigravity (agy) CLIs (uses your existing
+                                    # OR install the codex / antigravity (agy) / grok CLIs (uses your existing
                                     # subscription — no API key needed)
 
 # 3. Ask anything
@@ -312,7 +312,7 @@ Attach one image (e.g. a UI screenshot) so vision-capable providers can critique
 
 - Single image per query, raw size up to 10 MB, extensions: png / jpg / jpeg / webp / gif.
 - `gemini`, `openai`, `grok`, and `perplexity` receive the image alongside the prompt.
-- CLI providers answer through their vision sibling: `codex` via `openai`, `antigravity` via `gemini` (the slot is marked as a fallback). If the sibling is unusable (no API key) or already answering in its own slot, the CLI provider answers text-only instead.
+- CLI providers answer through their vision sibling: `codex` via `openai`, `antigravity` via `gemini`, `grok-cli` via `grok` (the slot is marked as a fallback). If the sibling is unusable (no API key) or already answering in its own slot, the CLI provider answers text-only instead.
 
 Privacy: the image is sent to the providers that can see it, but its bytes are **not** written to cache entries or the saved `council-*.md` transcripts — only a hash of the image keys the cache.
 
@@ -399,12 +399,13 @@ export PERPLEXITY_API_KEY="your-key"
 
 ### CLI Providers (subscription auth, no API key)
 
-If `codex` or `agy` CLIs are installed and on `PATH`, they're discovered automatically and **preferred over their API siblings** by default:
+If the `codex`, `agy`, or `grok` CLIs are installed and on `PATH`, they're discovered automatically and **preferred over their API siblings** by default:
 
 - `codex` (OpenAI Codex CLI) shadows the `openai` API provider
 - `antigravity` (Antigravity CLI, `agy`) shadows the `gemini` API provider
+- `grok-cli` (xAI Grok CLI, `grok`) shadows the `grok` API provider — defaults to `grok-composer-2.5-fast`, override with `GROK_CLI_MODEL`
 
-CLI providers use your existing CLI subscription — no API key, no per-call cost. To opt back into the API variant for a single call, pass it explicitly: `--providers=openai` or `--providers=gemini`. Listing both API and CLI together (e.g., `--providers=gemini,antigravity`) runs them side-by-side for comparison.
+CLI providers use your existing CLI subscription — no API key, no per-call cost. To opt back into the API variant for a single call, pass it explicitly: `--providers=openai`, `--providers=gemini`, or `--providers=grok`. Listing both API and CLI together (e.g., `--providers=grok,grok-cli`) runs them side-by-side for comparison.
 
 If a CLI provider fails at query time and its API sibling's key is set, the council automatically retries through that API sibling and marks the slot as a fallback (the answer is shown under the CLI slot with the API model's name and a "fell back to … API" note). The fallback is skipped when the sibling is already in your selected providers, so you never get the same vendor's answer twice.
 

--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ If the `codex`, `agy`, or `grok` CLIs are installed and on `PATH`, they're disco
 
 - `codex` (OpenAI Codex CLI) shadows the `openai` API provider
 - `antigravity` (Antigravity CLI, `agy`) shadows the `gemini` API provider
-- `grok-cli` (xAI Grok CLI, `grok`) shadows the `grok` API provider — defaults to `grok-composer-2.5-fast`, override with `GROK_CLI_MODEL`
+- `grok-cli` (xAI Grok CLI, `grok`) shadows the `grok` API provider — uses the grok CLI's own default model unless `GROK_CLI_MODEL` is set
 
 CLI providers use your existing CLI subscription — no API key, no per-call cost. To opt back into the API variant for a single call, pass it explicitly: `--providers=openai`, `--providers=gemini`, or `--providers=grok`. Listing both API and CLI together (e.g., `--providers=grok,grok-cli`) runs them side-by-side for comparison.
 
@@ -414,6 +414,7 @@ Override CLI model selection (defaults mirror what each CLI picks itself):
 ```bash
 export CODEX_MODEL="gpt-5-codex"                # default: gpt-5.5
 export ANTIGRAVITY_MODEL="Gemini 3.1 Pro (High)"  # default: Gemini 3.5 Flash (High)
+export GROK_CLI_MODEL="grok-4.3"                # default: the grok CLI's own default model
 ```
 
 ### Verbosity

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,7 +41,7 @@ bats --verbose-run tests/cache.bats
 | File | Tests | Coverage |
 |------|-------|----------|
 | `cache.bats` | 26 tests | cache_key (incl. verbosity/token/image components), cache_get/set, cache_valid, TTL, clear, self-ignoring dir |
-| `cli-providers.bats` | 44 tests | codex/antigravity/grok-cli discovery, CLI-prefers-API policy, shadow_origin↔api_sibling single source, --list-available / --list-default, flag parsing, coerce_result_json JSON guard, CLI→API fallback (dedup, cache reuse, missing-script, round 2), gated E2E |
+| `cli-providers.bats` | 45 tests | codex/antigravity/grok-cli discovery, CLI-prefers-API policy, shadow_origin↔api_sibling single source, --list-available / --list-default, flag parsing, coerce_result_json JSON guard, CLI→API fallback (dedup, cache reuse, missing-script, round 2), gated E2E |
 | `display.bats` | 43 tests | tmux/iTerm2 detection, wrapper no-op behavior, manifest writes, pane gating, tty probe, pane env forwarding, waiting-line truncation + autowrap guard, renderer selection (Rich feature probe, uv route + timeout, perl fallback, COUNCIL_RENDERER=perl, runtime fallback + stdout forwarding, think-block styling incl. unclosed tags, code-theme direction, link style, COLUMNS=0) |
 | `keys.bats` | 7 tests | XAI_API_KEY ↔ GROK_API_KEY resolution, precedence, silent-conflict policy |
 | `roles.bats` | 47 tests | presets, validation, prompt injection, assignment, local-council role resolution + member count |
@@ -49,11 +49,11 @@ bats --verbose-run tests/cache.bats
 | `verbosity.bats` | 9 tests | brief/standard/detailed directives, fallback to standard |
 | `query-council.bats` | 26 tests | argument parsing, error cases, flags, local-council fallback hint, model-fallback wrapper (preferred-then-fallback retry, cached-verdict skip, explicit `<PROVIDER>_MODEL` opt-out, no verdict remembered when the fallback also fails), round 2 and CLI-sibling fallback carrying `model_fallback` |
 | `argmax.bats` | 4 tests | large response/prompt/debate-round-2 round-trip through final JSON (MSYS ARG_MAX marshalling guard) |
-| `fake-clis.bats` | 20 tests | fixture self-checks, codex.sh/antigravity.sh/grok-cli.sh against fake binaries |
+| `fake-clis.bats` | 21 tests | fixture self-checks, codex.sh/antigravity.sh/grok-cli.sh against fake binaries |
 | `format-output.bats` | 13 tests | defensive parsing: empty/missing/non-string responses, raw preservation, CLI→API fallback-note rendering, model-fallback note (preferred model named, absent when unset) |
 | `prompts.bats` | 11 tests | template loading, {{VAR}} interpolation, role-injection rendering |
 | `agent-analysis.bats` | 11 tests | validate-analysis.sh contract enforcement, schema sync |
-| `check-status.bats` | 25 tests | two-tier CLI availability, remediation strings, HTTP probe branches (401/403/500/000), rejected-key classification (Gemini/xAI answer a bad key with 400, not 401) and its false-positive guards (a typo'd model is not a bad key), transfer-failure exit codes, curl writing nothing, unusable jq, Perplexity's minimum max_tokens, `-X POST` and `--max-time` on every probe, temp-file cleanup, keys off the curl argv, ms clock |
+| `check-status.bats` | 26 tests | two-tier CLI availability, remediation strings, HTTP probe branches (401/403/500/000), rejected-key classification (Gemini/xAI answer a bad key with 400, not 401) and its false-positive guards (a typo'd model is not a bad key), transfer-failure exit codes, curl writing nothing, unusable jq, Perplexity's minimum max_tokens, `-X POST` and `--max-time` on every probe, temp-file cleanup, keys off the curl argv, ms clock |
 | `jobs.bats` | 16 tests | job store, --async lifecycle, --result/--jobs/--cancel, self-ignoring cache dir |
 | `stop-gate.bats` | 10 tests | opt-in gating, loop guards, BLOCK verdict, fail-open |
 | `theme.bats` | 24 tests | terminal theme detection, theme-aware emphasis + muted-text (faint/gray) rendering |
@@ -65,7 +65,7 @@ bats --verbose-run tests/cache.bats
 | `retry.bats` | 11 tests | curl_with_retry backoff + status handling, curl_secret_config off-argv config file, ensure_error_body http_status stamping (object and string `.error`, Gemini's string `.error.status` left alone, synthesised message, 200 passthrough) |
 | `model_fallback.bats` | 28 tests | is_model_unavailable_error classifier (positive/negative fixtures from real vendor bodies), model_fallback_for pairs, verdict cache (TTL, provider+model+key scoping, corrupt/fractional-timestamp guards), model_fallback_key_hash, gated real-API test (grok-4.5's EU region block, end to end) |
 
-**Total: 432 tests** across 24 `.bats` files.
+**Total: 435 tests** across 24 `.bats` files.
 
 ### Hermetic CLI Fixture
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -41,7 +41,7 @@ bats --verbose-run tests/cache.bats
 | File | Tests | Coverage |
 |------|-------|----------|
 | `cache.bats` | 26 tests | cache_key (incl. verbosity/token/image components), cache_get/set, cache_valid, TTL, clear, self-ignoring dir |
-| `cli-providers.bats` | 38 tests | codex/antigravity discovery, CLI-prefers-API policy, shadow_origin↔api_sibling single source, --list-available / --list-default, flag parsing, coerce_result_json JSON guard, CLI→API fallback (dedup, cache reuse, missing-script, round 2), gated E2E |
+| `cli-providers.bats` | 44 tests | codex/antigravity/grok-cli discovery, CLI-prefers-API policy, shadow_origin↔api_sibling single source, --list-available / --list-default, flag parsing, coerce_result_json JSON guard, CLI→API fallback (dedup, cache reuse, missing-script, round 2), gated E2E |
 | `display.bats` | 43 tests | tmux/iTerm2 detection, wrapper no-op behavior, manifest writes, pane gating, tty probe, pane env forwarding, waiting-line truncation + autowrap guard, renderer selection (Rich feature probe, uv route + timeout, perl fallback, COUNCIL_RENDERER=perl, runtime fallback + stdout forwarding, think-block styling incl. unclosed tags, code-theme direction, link style, COLUMNS=0) |
 | `keys.bats` | 7 tests | XAI_API_KEY ↔ GROK_API_KEY resolution, precedence, silent-conflict policy |
 | `roles.bats` | 47 tests | presets, validation, prompt injection, assignment, local-council role resolution + member count |
@@ -49,7 +49,7 @@ bats --verbose-run tests/cache.bats
 | `verbosity.bats` | 9 tests | brief/standard/detailed directives, fallback to standard |
 | `query-council.bats` | 26 tests | argument parsing, error cases, flags, local-council fallback hint, model-fallback wrapper (preferred-then-fallback retry, cached-verdict skip, explicit `<PROVIDER>_MODEL` opt-out, no verdict remembered when the fallback also fails), round 2 and CLI-sibling fallback carrying `model_fallback` |
 | `argmax.bats` | 4 tests | large response/prompt/debate-round-2 round-trip through final JSON (MSYS ARG_MAX marshalling guard) |
-| `fake-clis.bats` | 14 tests | fixture self-checks, codex.sh/antigravity.sh against fake binaries |
+| `fake-clis.bats` | 20 tests | fixture self-checks, codex.sh/antigravity.sh/grok-cli.sh against fake binaries |
 | `format-output.bats` | 13 tests | defensive parsing: empty/missing/non-string responses, raw preservation, CLI→API fallback-note rendering, model-fallback note (preferred model named, absent when unset) |
 | `prompts.bats` | 11 tests | template loading, {{VAR}} interpolation, role-injection rendering |
 | `agent-analysis.bats` | 11 tests | validate-analysis.sh contract enforcement, schema sync |
@@ -65,11 +65,11 @@ bats --verbose-run tests/cache.bats
 | `retry.bats` | 11 tests | curl_with_retry backoff + status handling, curl_secret_config off-argv config file, ensure_error_body http_status stamping (object and string `.error`, Gemini's string `.error.status` left alone, synthesised message, 200 passthrough) |
 | `model_fallback.bats` | 28 tests | is_model_unavailable_error classifier (positive/negative fixtures from real vendor bodies), model_fallback_for pairs, verdict cache (TTL, provider+model+key scoping, corrupt/fractional-timestamp guards), model_fallback_key_hash, gated real-API test (grok-4.5's EU region block, end to end) |
 
-**Total: 420 tests** across 24 `.bats` files.
+**Total: 432 tests** across 24 `.bats` files.
 
 ### Hermetic CLI Fixture
 
-`tests/fixtures/fake-clis.bash` installs real fake `codex`/`agy`
+`tests/fixtures/fake-clis.bash` installs real fake `codex`/`agy`/`grok`
 executables into a temp dir prepended to `PATH`, so provider scripts, async
 jobs, and the stop gate run end-to-end with no network or real CLIs:
 

--- a/commands/ask.md
+++ b/commands/ask.md
@@ -57,8 +57,8 @@ any provider questions:
      ```
      - "Run local council" → local mode (Step 2).
      - "How to add a provider" → show the setup hint (set an API key, or install
-       the `codex` / `agy` (Antigravity) CLI; `/claude-council:status` shows
-       what's available) and stop.
+       the `codex` / `agy` (Antigravity) / `grok` CLI; `/claude-council:status`
+       shows what's available) and stop.
      - "Cancel" → stop.
 
 **Never pass `--local` to query-council.sh or run-council.sh** — it is a

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -30,11 +30,11 @@
         +-------+-------+-------+-------+-------+-------+
         |       |       |       |       |       |       |
         v       v       v       v       v       v       v
-   +--------+ +-----+ +------+ +-----+ +------+ +-----------+
-   | gemini | |open | | grok | |perp | |codex | |antigravity|
-   |  .sh   | | .sh | |  .sh | |.sh  | |  .sh | |    .sh    |
-   +--------+ +-----+ +------+ +-----+ +------+ +-----------+
-   (API)      (API)   (API)    (API)   (CLI)    (CLI)
+   +--------+ +-----+ +------+ +-----+ +------+ +-----------+ +---------+
+   | gemini | |open | | grok | |perp | |codex | |antigravity| | grok-   |
+   |  .sh   | | .sh | |  .sh | |.sh  | |  .sh | |    .sh    | | cli.sh  |
+   +--------+ +-----+ +------+ +-----+ +------+ +-----------+ +---------+
+   (API)      (API)   (API)    (API)   (CLI)    (CLI)         (CLI)
         |               |               |               |
         |    +----------+----------+----------+        |
         +--->|      lib/cache.sh   |<---------+--------+
@@ -135,17 +135,18 @@ Two flavors share the interface:
 
 - **API providers** (`gemini`, `openai`, `grok`, `perplexity`) — gated on
   `{PROVIDER}_API_KEY`, talk to vendor APIs over HTTPS, charge per call.
-- **CLI providers** (`codex`, `antigravity`) — gated on the binary being on
-  `PATH`, use the user's existing CLI subscription auth, no per-call cost.
-  When both an API and CLI sibling exist (codex+openai, antigravity+gemini),
-  the orchestrator prefers the CLI by default; explicit `--providers` wins
-  over the policy. If a CLI provider fails at query time, the council retries
-  through its API sibling (when that key is set) and marks the slot as a fallback.
+- **CLI providers** (`codex`, `antigravity`, `grok-cli`) — gated on the binary
+  being on `PATH`, use the user's existing CLI subscription auth, no per-call cost.
+  When both an API and CLI sibling exist (codex+openai, antigravity+gemini,
+  grok-cli+grok), the orchestrator prefers the CLI by default; explicit
+  `--providers` wins over the policy. If a CLI provider fails at query time, the
+  council retries through its API sibling (when that key is set) and marks the
+  slot as a fallback.
 
 Environment-based configuration:
 - `{PROVIDER}_API_KEY` - Required authentication for API providers
 - `{PROVIDER}_MODEL` - Model override (also applies to CLI providers via
-  `CODEX_MODEL` / `ANTIGRAVITY_MODEL`)
+  `CODEX_MODEL` / `ANTIGRAVITY_MODEL` / `GROK_CLI_MODEL`)
 - `COUNCIL_MAX_TOKENS` - Response length limit (API providers only)
 - `COUNCIL_DEBUG` - Enable verbose logging
 
@@ -161,8 +162,9 @@ Per-provider disposition when an image is attached:
   gemini as an `inlineData` part, openai as `input_image` (Responses API) or
   `image_url` (Chat Completions), grok and perplexity as an OpenAI-compatible
   `image_url` data-URI on their `/chat/completions` endpoint.
-- **codex, antigravity** (CLI, cannot accept an image) route to their vision
-  API sibling — codex→openai, antigravity→gemini — with the image.
+- **codex, antigravity, grok-cli** (CLI, cannot accept an image) route to their
+  vision API sibling — codex→openai, antigravity→gemini, grok-cli→grok — with
+  the image.
 
 Privacy invariant: only the image's SHA-256 keys the cache. The base64 lives
 solely in a temp file passed to providers; it is never written to cache entries
@@ -429,7 +431,8 @@ claude-council/
 │   │   ├── grok.sh              # API
 │   │   ├── perplexity.sh        # API
 │   │   ├── codex.sh             # CLI (subscription auth, shadows openai)
-│   │   └── antigravity.sh       # CLI (subscription auth, shadows gemini)
+│   │   ├── antigravity.sh       # CLI (subscription auth, shadows gemini)
+│   │   └── grok-cli.sh          # CLI (subscription auth, shadows grok)
 │   └── lib/
 │       ├── cache.sh             # Caching utilities
 │       ├── display.sh           # Streaming tmux pane + iTerm2 lifecycle
@@ -468,7 +471,7 @@ claude-council/
 │   ├── argmax.bats              # ARG_MAX marshalling round-trip guards
 │   ├── cache.bats
 │   ├── check-status.bats
-│   ├── cli-providers.bats       # CLI providers (codex, antigravity)
+│   ├── cli-providers.bats       # CLI providers (codex, antigravity, grok-cli)
 │   ├── display.bats
 │   ├── export.bats
 │   ├── fake-clis.bats

--- a/scripts/check-status.sh
+++ b/scripts/check-status.sh
@@ -212,6 +212,8 @@ remediation_for() {
         codex:no_binary)      echo "npm install -g @openai/codex" ;;
         codex:unauthed)       echo "codex login" ;;
         antigravity:no_binary) echo "install the Antigravity CLI (agy)" ;;
+        grok-cli:no_binary)   echo "install the Grok CLI (grok)" ;;
+        grok-cli:unauthed)    echo "grok login" ;;
         *:auth_error)         echo "key rejected - regenerate it" ;;
         *)                    echo "" ;;
     esac
@@ -228,9 +230,11 @@ openai_status=$(check_provider "openai" "OPENAI_API_KEY" "OPENAI_MODEL" "gpt-5.6
 grok_status=$(check_provider "grok" "GROK_API_KEY" "GROK_MODEL" "grok-4.5")
 perplexity_status=$(check_provider "perplexity" "PERPLEXITY_API_KEY" "PERPLEXITY_MODEL" "sonar-reasoning-pro")
 # codex login status exits non-zero when logged out; agy has no
-# equivalent offline auth probe, so it stays a single-tier check
+# equivalent offline auth probe, so it stays a single-tier check. `grok models`
+# exits non-zero when logged out, giving grok-cli the same two-tier probe as codex.
 codex_status=$(check_cli_provider "codex" "codex" login status)
 antigravity_status=$(check_cli_provider "antigravity" "agy")
+grokcli_status=$(check_cli_provider "grok-cli" "grok" models)
 
 # Format output
 # Usage: format_status <display_name> <provider_id> <status>
@@ -295,6 +299,7 @@ format_status "Grok"       "grok"       "$grok_status"
 format_status "Perplexity" "perplexity" "$perplexity_status"
 format_status "Codex CLI"  "codex"      "$codex_status"
 format_status "Antigravity" "antigravity" "$antigravity_status"
+format_status "Grok CLI"   "grok-cli"   "$grokcli_status"
 
 echo ""
 
@@ -307,6 +312,7 @@ available_count=0
 [[ "$perplexity_status" == ok:* ]] && available_count=$((available_count + 1))
 [[ "$codex_status" == ok:* ]] && available_count=$((available_count + 1))
 [[ "$antigravity_status" == ok:* ]] && available_count=$((available_count + 1))
+[[ "$grokcli_status" == ok:* ]] && available_count=$((available_count + 1))
 
-echo -e "${DIM}${available_count}/6 providers available${RESET}"
+echo -e "${DIM}${available_count}/7 providers available${RESET}"
 echo ""

--- a/scripts/check-status.sh
+++ b/scripts/check-status.sh
@@ -191,9 +191,19 @@ check_cli_provider() {
         return
     fi
 
-    if [[ $# -gt 0 ]] && ! "$binary" "$@" >/dev/null 2>&1; then
-        echo "unauthed"
-        return
+    # A probe can signal a logged-out state two ways: a non-zero exit (codex
+    # login status) or a "not authenticated" message with exit 0 (grok models),
+    # so both the exit code and the output classify auth.
+    local probe_out
+    if [[ $# -gt 0 ]]; then
+        if ! probe_out=$("$binary" "$@" 2>/dev/null); then
+            echo "unauthed"
+            return
+        fi
+        if echo "$probe_out" | grep -qi "not authenticated"; then
+            echo "unauthed"
+            return
+        fi
     fi
 
     end_time=$(now_ms)
@@ -231,7 +241,8 @@ grok_status=$(check_provider "grok" "GROK_API_KEY" "GROK_MODEL" "grok-4.5")
 perplexity_status=$(check_provider "perplexity" "PERPLEXITY_API_KEY" "PERPLEXITY_MODEL" "sonar-reasoning-pro")
 # codex login status exits non-zero when logged out; agy has no
 # equivalent offline auth probe, so it stays a single-tier check. `grok models`
-# exits non-zero when logged out, giving grok-cli the same two-tier probe as codex.
+# prints "You are not authenticated." with exit 0 when logged out, which the
+# probe's output match classifies, giving grok-cli the same two tiers as codex.
 codex_status=$(check_cli_provider "codex" "codex" login status)
 antigravity_status=$(check_cli_provider "antigravity" "agy")
 grokcli_status=$(check_cli_provider "grok-cli" "grok" models)

--- a/scripts/lib/display.sh
+++ b/scripts/lib/display.sh
@@ -306,7 +306,7 @@ provider_color_rgb() {
     case "$2" in
         gemini|antigravity) printf -v "$__out" '59;130;246'   ;;  # blue-500
         openai|codex)      printf -v "$__out" '100;116;139'  ;;  # slate-500
-        grok)              printf -v "$__out" '239;68;68'    ;;  # red-500
+        grok|grok-cli)     printf -v "$__out" '239;68;68'    ;;  # red-500
         perplexity)        printf -v "$__out" '22;163;74'    ;;  # green-600
         *)                 printf -v "$__out" '113;113;122'  ;;  # zinc-500
     esac

--- a/scripts/lib/pane-watcher.sh
+++ b/scripts/lib/pane-watcher.sh
@@ -92,7 +92,7 @@ print_banner() {
     case "$name" in
         gemini|antigravity) bg='30;64;175';   fg='255;255;255'; accent='147;197;253' ;;  # blue-700/300
         openai|codex)      bg='229;231;235'; fg='31;41;55';    accent='100;116;139' ;;  # gray-200/slate-500
-        grok)              bg='185;28;28';   fg='255;255;255'; accent='252;165;165' ;;  # red-700/300
+        grok|grok-cli)     bg='185;28;28';   fg='255;255;255'; accent='252;165;165' ;;  # red-700/300
         perplexity)        bg='21;128;61';   fg='255;255;255'; accent='134;239;172' ;;  # green-700/300
         *)                 bg='55;65;81';    fg='255;255;255'; accent='156;163;175' ;;  # gray-700/400
     esac

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -105,12 +105,14 @@ default_provider_set() {
 # Default model per provider. CLI defaults mirror what the CLI itself picks
 # when invoked without -m, so the cache key and pane header match what's
 # actually run. Bump when the CLI ships a new default we want to track.
+# grok-cli's default differs by auth mode, so grok-cli.sh passes no -m unless
+# GROK_CLI_MODEL is set and the unset case reads as the label "default" here.
 get_model() {
     case "$1" in
         gemini)     echo "${GEMINI_MODEL:-gemini-3.1-pro-preview}" ;;
         openai)     echo "${OPENAI_MODEL:-gpt-5.6-sol}" ;;
         grok)       echo "${GROK_MODEL:-grok-4.5}" ;;
-        grok-cli)   echo "${GROK_CLI_MODEL:-grok-composer-2.5-fast}" ;;
+        grok-cli)   echo "${GROK_CLI_MODEL:-default}" ;;
         perplexity) echo "${PERPLEXITY_MODEL:-sonar-reasoning-pro}" ;;
         codex)      echo "${CODEX_MODEL:-gpt-5.5}" ;;
         antigravity) echo "${ANTIGRAVITY_MODEL:-Gemini 3.5 Flash (High)}" ;;

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -4,7 +4,7 @@
 
 # Discover which provider scripts are available to query.
 # API providers are gated on their <NAME>_API_KEY env var; subscription-auth
-# CLI providers (codex, antigravity) are gated on their binary being on PATH.
+# CLI providers (codex, antigravity, grok-cli) are gated on their binary being on PATH.
 discover_providers() {
     local available=()
 
@@ -20,6 +20,9 @@ discover_providers() {
                 ;;
             antigravity)
                 command -v agy >/dev/null 2>&1 && is_available=true
+                ;;
+            grok-cli)
+                command -v grok >/dev/null 2>&1 && is_available=true
                 ;;
             *)
                 # API providers gate on <NAME>_API_KEY — the same check
@@ -40,7 +43,7 @@ discover_providers() {
 # Both shadow_origin and api_sibling derive from this list, so they cannot
 # drift: adding a pair is a one-line change here that propagates to
 # prefer_cli_over_api, the --list-available display, and the CLI→API fallback.
-SHADOW_PAIRS="openai:codex gemini:antigravity"
+SHADOW_PAIRS="openai:codex gemini:antigravity grok:grok-cli"
 
 # Returns the CLI provider that shadows the given API provider (empty if none).
 shadow_origin() {
@@ -107,6 +110,7 @@ get_model() {
         gemini)     echo "${GEMINI_MODEL:-gemini-3.1-pro-preview}" ;;
         openai)     echo "${OPENAI_MODEL:-gpt-5.6-sol}" ;;
         grok)       echo "${GROK_MODEL:-grok-4.5}" ;;
+        grok-cli)   echo "${GROK_CLI_MODEL:-grok-composer-2.5-fast}" ;;
         perplexity) echo "${PERPLEXITY_MODEL:-sonar-reasoning-pro}" ;;
         codex)      echo "${CODEX_MODEL:-gpt-5.5}" ;;
         antigravity) echo "${ANTIGRAVITY_MODEL:-Gemini 3.5 Flash (High)}" ;;
@@ -148,13 +152,14 @@ coerce_result_json() {
 }
 
 # Vendor color for a provider name. CLI variants share their vendor's color
-# (codex with openai, antigravity with gemini) since they speak for the same vendor.
+# (codex with openai, antigravity with gemini, grok-cli with grok) since they
+# speak for the same vendor.
 # Caller is responsible for defining BLUE/WHITE/RED/GREEN/CYAN globals.
 provider_color() {
     case "$1" in
         gemini|antigravity) echo -e "${BLUE}" ;;
         openai|codex)      echo -e "${WHITE}" ;;
-        grok)              echo -e "${RED}" ;;
+        grok|grok-cli)     echo -e "${RED}" ;;
         perplexity)        echo -e "${GREEN}" ;;
         *)                 echo -e "${CYAN}" ;;
     esac
@@ -165,7 +170,7 @@ provider_emoji() {
     case "$1" in
         gemini|antigravity) echo "🟦" ;;
         openai|codex)      echo "🔳" ;;
-        grok)              echo "🟥" ;;
+        grok|grok-cli)     echo "🟥" ;;
         perplexity)        echo "🟩" ;;
         *)                 echo "⬛" ;;
     esac

--- a/scripts/providers/grok-cli.sh
+++ b/scripts/providers/grok-cli.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# ABOUTME: Queries the xAI Grok CLI in headless single-turn mode using subscription auth
+# ABOUTME: Availability is gated on the grok binary being on PATH, not an API key
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/verbosity.sh"
+source "$SCRIPT_DIR/../lib/providers.sh"
+
+verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
+
+PROMPT="${1:-}"
+# A large prompt (e.g. a big --file) arrives via a temp file to stay off
+# the process argv, where the OS would reject it as "argument list too long".
+if [[ "$PROMPT" == "--prompt-file" ]]; then
+    PROMPT=$(cat "${2:?--prompt-file requires a path}")
+fi
+
+if [[ -z "$PROMPT" ]]; then
+    echo "Error: No prompt provided" >&2
+    exit 1
+fi
+
+if ! command -v grok >/dev/null 2>&1; then
+    echo "Error: grok CLI not found on PATH" >&2
+    exit 1
+fi
+
+SYSTEM="${VERBOSITY_PREFIX:+$VERBOSITY_PREFIX }$BASE_SYSTEM_PROMPT"
+FULL_PROMPT="${SYSTEM}
+
+${PROMPT}"
+
+MODEL=$(get_model grok-cli)
+# -p: single-turn prompt — grok prints the answer to stdout and exits, no TUI.
+# --output-format plain: bare text, so the response needs no JSON unwrapping.
+# --sandbox read-only: the council only reads stdout, so pin grok's built-in
+# read-only profile rather than inherit a permissive user config — a defense
+# against model-generated file writes or shell from an adversarial prompt
+# (mirrors codex's -s read-only and agy's --sandbox guard).
+ARGS=(-p "$FULL_PROMPT" --output-format plain -m "$MODEL" --sandbox read-only)
+
+# Bound the CLI the way API providers are bounded by curl --max-time. GNU
+# `timeout` is absent on stock macOS, so use perl's alarm (perl is already a
+# renderer dependency); the pending alarm survives exec and kills the CLI after
+# COUNCIL_TIMEOUT seconds, surfacing as exit 142 (128 + SIGALRM).
+COUNCIL_TIMEOUT="${COUNCIL_TIMEOUT:-300}"
+
+ERR_TMP=$(mktemp)
+trap 'rm -f "$ERR_TMP"' EXIT
+
+if RESPONSE=$(perl -e 'alarm shift; exec @ARGV' "$COUNCIL_TIMEOUT" grok "${ARGS[@]}" 2>"$ERR_TMP"); then
+    echo "$RESPONSE"
+else
+    rc=$?
+    if [[ $rc -eq 142 ]]; then
+        echo "Error from grok CLI: timed out after ${COUNCIL_TIMEOUT}s" >&2
+    else
+        ERR_MSG=$(tr '\n' ' ' < "$ERR_TMP" | head -c 500)
+        echo "Error from grok CLI: ${ERR_MSG:-non-zero exit}" >&2
+    fi
+    exit 1
+fi

--- a/scripts/providers/grok-cli.sh
+++ b/scripts/providers/grok-cli.sh
@@ -6,7 +6,6 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/verbosity.sh"
-source "$SCRIPT_DIR/../lib/providers.sh"
 
 verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
 
@@ -32,14 +31,17 @@ FULL_PROMPT="${SYSTEM}
 
 ${PROMPT}"
 
-MODEL=$(get_model grok-cli)
 # -p: single-turn prompt — grok prints the answer to stdout and exits, no TUI.
 # --output-format plain: bare text, so the response needs no JSON unwrapping.
 # --sandbox read-only: the council only reads stdout, so pin grok's built-in
 # read-only profile rather than inherit a permissive user config — a defense
 # against model-generated file writes or shell from an adversarial prompt
 # (mirrors codex's -s read-only and agy's --sandbox guard).
-ARGS=(-p "$FULL_PROMPT" --output-format plain -m "$MODEL" --sandbox read-only)
+ARGS=(-p "$FULL_PROMPT" --output-format plain --sandbox read-only)
+# -m only on an explicit override: the CLI's default model differs by auth
+# mode, and a pinned id is rejected ("unknown model id") under XAI_API_KEY
+# env auth, so an unset GROK_CLI_MODEL defers to the CLI's own default.
+[[ -n "${GROK_CLI_MODEL:-}" ]] && ARGS+=(-m "$GROK_CLI_MODEL")
 
 # Bound the CLI the way API providers are bounded by curl --max-time. GNU
 # `timeout` is absent on stock macOS, so use perl's alarm (perl is already a

--- a/scripts/query-council.sh
+++ b/scripts/query-council.sh
@@ -197,7 +197,7 @@ if [[ "$LIST_AVAILABLE" == true ]]; then
     if [[ ${#DISCOVERED[@]} -eq 0 ]]; then
         echo "No providers configured."
         echo "  Set an API key (GEMINI_API_KEY, OPENAI_API_KEY, XAI_API_KEY/GROK_API_KEY, or PERPLEXITY_API_KEY)"
-        echo "  or install a CLI agent (codex, agy)."
+        echo "  or install a CLI agent (codex, agy, grok)."
         exit 0
     fi
     read -ra DEFAULT_SET <<< "$(prefer_cli_over_api "${DISCOVERED[@]+"${DISCOVERED[@]}"}")"
@@ -274,7 +274,7 @@ fi
 if [[ ${#PROVIDERS[@]} -eq 0 ]]; then
     echo "Error: No providers configured." >&2
     echo "  Set an API key (GEMINI_API_KEY, OPENAI_API_KEY, XAI_API_KEY/GROK_API_KEY, or PERPLEXITY_API_KEY)" >&2
-    echo "  or install a CLI agent (codex, agy)." >&2
+    echo "  or install a CLI agent (codex, agy, grok)." >&2
     echo "  Or run '/claude-council:ask --local' for a local Claude-only council (same-model, no API keys)." >&2
     exit 1
 fi

--- a/scripts/stop-review-gate.sh
+++ b/scripts/stop-review-gate.sh
@@ -26,7 +26,7 @@ IFS=$'\t' read -r ENABLED PROVIDER MAX_ITER < <(
 # constrain it to the known set — a config value like "../../evil" must never
 # select an arbitrary script. Unknown provider -> fail open.
 case "$PROVIDER" in
-    gemini|openai|grok|perplexity|codex|antigravity) ;;
+    gemini|openai|grok|grok-cli|perplexity|codex|antigravity) ;;
     *) exit 0 ;;
 esac
 

--- a/tests/check-status.bats
+++ b/tests/check-status.bats
@@ -36,6 +36,15 @@ setup() {
     [[ "$output" == *"codex login"* ]]
 }
 
+@test "check-status: grok logged out (stdout message, exit 0) is not authenticated" {
+    # The real grok CLI prints "You are not authenticated." and exits 0, so the
+    # probe must classify the unauth state from stdout, not the exit code.
+    export COUNCIL_FAKE_BEHAVIOR=auth-failure
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"grok login"* ]]
+}
+
 @test "check-status: unauthenticated codex is not counted available" {
     export COUNCIL_FAKE_BEHAVIOR=auth-failure
     run bash "$SCRIPT"

--- a/tests/check-status.bats
+++ b/tests/check-status.bats
@@ -40,8 +40,9 @@ setup() {
     export COUNCIL_FAKE_BEHAVIOR=auth-failure
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
-    # antigravity (no auth probe) is the only available provider
-    [[ "$output" == *"1/6 providers available"* ]]
+    # antigravity (no auth probe) is the only available provider; codex and
+    # grok-cli both probe auth and report unauthed under auth-failure
+    [[ "$output" == *"1/7 providers available"* ]]
 }
 
 @test "check-status: missing API key shows exact export remediation" {
@@ -59,6 +60,7 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"npm install -g @openai/codex"* ]]
     [[ "$output" == *"install the Antigravity CLI (agy)"* ]]
+    [[ "$output" == *"install the Grok CLI (grok)"* ]]
 }
 
 # Shadow curl with a stub that writes a scripted body to curl's -o target and
@@ -102,8 +104,8 @@ EOF
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Connected"* ]]
-    # 4 API providers + codex + antigravity, all healthy
-    [[ "$output" == *"6/6 providers available"* ]]
+    # 4 API providers + codex + antigravity + grok-cli, all healthy
+    [[ "$output" == *"7/7 providers available"* ]]
 }
 
 @test "check-status: HTTP 401 reports auth failure with regenerate remediation" {
@@ -116,8 +118,8 @@ EOF
     # Every API provider must classify 401, not just whichever one happens to be
     # first: a substring match alone cannot tell four rows from one.
     [ "$(auth_failures "$output")" -eq 4 ]
-    # Only the two CLI providers remain available
-    [[ "$output" == *"2/6 providers available"* ]]
+    # Only the three CLI providers remain available (codex, antigravity, grok-cli)
+    [[ "$output" == *"3/7 providers available"* ]]
 }
 
 # Gemini answers 403 PERMISSION_DENIED for a referer-restricted key, OpenAI for a
@@ -140,7 +142,7 @@ EOF
     [[ "$output" == *"Error (HTTP 500)"* ]]
     # A server-side fault is not a credentials problem
     [ "$(auth_failures "$output")" -eq 0 ]
-    [[ "$output" == *"2/6 providers available"* ]]
+    [[ "$output" == *"3/7 providers available"* ]]
 }
 
 @test "check-status: curl failure (000) reports a connection timeout" {
@@ -149,7 +151,7 @@ EOF
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Connection timeout"* ]]
-    [[ "$output" == *"2/6 providers available"* ]]
+    [[ "$output" == *"3/7 providers available"* ]]
 }
 
 # Gemini and xAI answer a rejected key with 400 rather than a 401, so the status

--- a/tests/cli-providers.bats
+++ b/tests/cli-providers.bats
@@ -171,6 +171,15 @@ source_lib_and_call() {
     [[ "$output" == "Gemini 3.5 Flash (High)" ]]
 }
 
+@test "get_model: grok-cli without an override labels the CLI's own default, not a pinned id" {
+    # grok-cli.sh passes no -m when GROK_CLI_MODEL is unset (the CLI's default
+    # differs by auth mode), so the display/cache label must say so rather than
+    # name a model that was never requested.
+    run source_lib_and_call 'unset GROK_CLI_MODEL; get_model grok-cli'
+    [ "$status" -eq 0 ]
+    [[ "$output" == "default" ]]
+}
+
 # ============================================================================
 # api_sibling — reverse of shadow_origin (CLI → API fallback target)
 # ============================================================================

--- a/tests/cli-providers.bats
+++ b/tests/cli-providers.bats
@@ -47,6 +47,13 @@ source_lib_and_call() {
     [[ "$output" == *"antigravity"* ]]
 }
 
+@test "discover_providers: includes grok-cli when grok binary is on PATH" {
+    if ! command_exists grok; then skip "grok CLI not installed"; fi
+    run source_lib_and_call 'discover_providers'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"grok-cli"* ]]
+}
+
 @test "discover_providers: excludes codex when binary is missing" {
     # Strip codex from PATH by running with a minimal PATH
     run bash -c "
@@ -59,6 +66,7 @@ source_lib_and_call() {
     [ "$status" -eq 0 ]
     [[ "$output" != *"codex"* ]]
     [[ "$output" != *"antigravity"* ]]
+    [[ "$output" != *"grok-cli"* ]]
 }
 
 @test "discover_providers: excludes API providers when keys unset" {
@@ -119,6 +127,15 @@ source_lib_and_call() {
     [[ ! "$output" =~ (^|[[:space:]])gemini([[:space:]]|$) ]]
 }
 
+@test "prefer_cli_over_api: drops grok when grok-cli is present" {
+    run source_lib_and_call 'prefer_cli_over_api grok-cli grok perplexity'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"grok-cli"* ]]
+    [[ "$output" == *"perplexity"* ]]
+    # bare grok must be gone, but grok-cli (which contains "grok") must remain
+    [[ ! "$output" =~ (^|[[:space:]])grok([[:space:]]|$) ]]
+}
+
 @test "prefer_cli_over_api: drops both API siblings when both CLIs present" {
     run source_lib_and_call 'prefer_cli_over_api codex antigravity openai gemini grok'
     [ "$status" -eq 0 ]
@@ -140,6 +157,12 @@ source_lib_and_call() {
     run source_lib_and_call 'shadow_origin gemini'
     [ "$status" -eq 0 ]
     [[ "$output" == "antigravity" ]]
+}
+
+@test "shadow_origin: grok is shadowed by grok-cli" {
+    run source_lib_and_call 'shadow_origin grok'
+    [ "$status" -eq 0 ]
+    [[ "$output" == "grok-cli" ]]
 }
 
 @test "get_model: antigravity default is a Gemini Flash model" {
@@ -164,6 +187,12 @@ source_lib_and_call() {
     [[ "$output" == "gemini" ]]
 }
 
+@test "api_sibling: grok-cli falls back to grok" {
+    run source_lib_and_call 'api_sibling grok-cli'
+    [ "$status" -eq 0 ]
+    [[ "$output" == "grok" ]]
+}
+
 @test "api_sibling: provider with no sibling yields empty" {
     run source_lib_and_call 'api_sibling grok'
     [ "$status" -eq 0 ]
@@ -176,7 +205,7 @@ source_lib_and_call() {
     run bash -c "
         export PROVIDERS_DIR='${PROVIDERS_DIR_REAL}'
         source '${PROVIDERS_LIB}'
-        for api in openai gemini; do
+        for api in openai gemini grok; do
             cli=\$(shadow_origin \"\$api\")
             back=\$(api_sibling \"\$cli\")
             [[ \"\$back\" == \"\$api\" ]] || { echo \"MISMATCH \$api -> \$cli -> \$back\"; exit 1; }
@@ -494,6 +523,11 @@ EOF
     [[ "$output" != *"Unknown flag"* ]]
 }
 
+@test "query-council: --providers grok-cli flag is accepted" {
+    run bash "$SCRIPT" --providers=grok-cli "test prompt" 2>&1
+    [[ "$output" != *"Unknown flag"* ]]
+}
+
 # ============================================================================
 # End-to-end CLI provider invocation (gated — set COUNCIL_E2E=1 to run)
 # ============================================================================
@@ -521,4 +555,12 @@ EOF
     [[ "$output" == *"OK"* ]]
     # Inline answer, not an artifact pointer
     [[ "$output" != *"file:///"* ]]
+}
+
+@test "grok-cli.sh: real grok answers inline for a trivial prompt (E2E)" {
+    [[ "${COUNCIL_E2E:-}" == "1" ]] || skip "set COUNCIL_E2E=1 to run real CLI calls"
+    if ! command_exists grok; then skip "grok CLI not installed"; fi
+    run "${PROVIDERS_DIR_REAL}/grok-cli.sh" "Reply with exactly the word: OK"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
 }

--- a/tests/fake-clis.bats
+++ b/tests/fake-clis.bats
@@ -34,6 +34,12 @@ teardown() {
     [[ "$output" == "$FAKE_BIN_DIR/agy" ]]
 }
 
+@test "fixture: fake grok shadows any real grok on PATH" {
+    run command -v grok
+    [ "$status" -eq 0 ]
+    [[ "$output" == "$FAKE_BIN_DIR/grok" ]]
+}
+
 # ============================================================================
 # codex.sh against the fake binary
 # ============================================================================
@@ -139,6 +145,59 @@ teardown() {
 }
 
 # ============================================================================
+# grok-cli.sh against the fake binary
+# ============================================================================
+
+@test "grok-cli.sh: returns fake response on valid behavior" {
+    export COUNCIL_FAKE_BEHAVIOR=valid
+    run "${PROVIDERS_DIR_REAL}/grok-cli.sh" "test prompt"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"FAKE-GROK-RESPONSE"* ]]
+}
+
+@test "grok-cli.sh: sends -p prompt, plain output, model flag, and read-only sandbox" {
+    export COUNCIL_FAKE_BEHAVIOR=valid
+    export GROK_CLI_MODEL="test-model-g"
+    run "${PROVIDERS_DIR_REAL}/grok-cli.sh" "the user question"
+    [ "$status" -eq 0 ]
+    local call
+    call=$(tail -1 "$COUNCIL_FAKE_STATE_DIR/calls.jsonl")
+    assert_json_eq "$call" '.bin' "grok"
+    # -p carries the user question as its value
+    [[ "$(echo "$call" | jq -r '.args | index("-p") as $i | .[$i+1]')" == *"the user question"* ]]
+    [[ "$(echo "$call" | jq -r '.args | index("--output-format") as $i | .[$i+1]')" == "plain" ]]
+    [[ "$(echo "$call" | jq -r '.args | index("-m") as $i | .[$i+1]')" == "test-model-g" ]]
+    [[ "$(echo "$call" | jq -r '.args | index("--sandbox") as $i | .[$i+1]')" == "read-only" ]]
+}
+
+@test "grok-cli.sh: pins a read-only sandbox so a permissive user config can't grant write access" {
+    export COUNCIL_FAKE_BEHAVIOR=valid
+    run "${PROVIDERS_DIR_REAL}/grok-cli.sh" "the user question"
+    [ "$status" -eq 0 ]
+    local call
+    call=$(tail -1 "$COUNCIL_FAKE_STATE_DIR/calls.jsonl")
+    [[ "$(echo "$call" | jq -r '.args | index("--sandbox") as $i | .[$i+1]')" == "read-only" ]]
+}
+
+@test "grok-cli.sh: a hung CLI is bounded by COUNCIL_TIMEOUT and reports a timeout" {
+    export COUNCIL_FAKE_BEHAVIOR=hang COUNCIL_FAKE_SLEEP=30 COUNCIL_TIMEOUT=1
+    local start end
+    start=$SECONDS
+    run --separate-stderr "${PROVIDERS_DIR_REAL}/grok-cli.sh" "test prompt"
+    end=$SECONDS
+    [ "$status" -eq 1 ]
+    [[ "$stderr" == *"timed out"* ]]
+    [ $((end - start)) -lt 10 ]
+}
+
+@test "grok-cli.sh: surfaces stderr and exits 1 on error behavior" {
+    export COUNCIL_FAKE_BEHAVIOR=error
+    run "${PROVIDERS_DIR_REAL}/grok-cli.sh" "test prompt"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"fake provider failure"* ]]
+}
+
+# ============================================================================
 # Discovery with fakes — replaces skip-gated coverage
 # ============================================================================
 
@@ -152,6 +211,7 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"codex"* ]]
     [[ "$output" == *"antigravity"* ]]
+    [[ "$output" == *"grok-cli"* ]]
 }
 
 @test "fixture: slow behavior delays the response" {

--- a/tests/fake-clis.bats
+++ b/tests/fake-clis.bats
@@ -170,6 +170,18 @@ teardown() {
     [[ "$(echo "$call" | jq -r '.args | index("--sandbox") as $i | .[$i+1]')" == "read-only" ]]
 }
 
+@test "grok-cli.sh: passes no -m when GROK_CLI_MODEL is unset, deferring to the CLI's own default" {
+    export COUNCIL_FAKE_BEHAVIOR=valid
+    unset GROK_CLI_MODEL
+    run "${PROVIDERS_DIR_REAL}/grok-cli.sh" "the user question"
+    [ "$status" -eq 0 ]
+    local call
+    call=$(tail -1 "$COUNCIL_FAKE_STATE_DIR/calls.jsonl")
+    assert_json_eq "$call" '.bin' "grok"
+    # A pinned id is rejected under XAI_API_KEY env auth, so no -m may appear
+    [[ "$(echo "$call" | jq -r '.args | index("-m")')" == "null" ]]
+}
+
 @test "grok-cli.sh: pins a read-only sandbox so a permissive user config can't grant write access" {
     export COUNCIL_FAKE_BEHAVIOR=valid
     run "${PROVIDERS_DIR_REAL}/grok-cli.sh" "the user question"

--- a/tests/fixtures/fake-clis.bash
+++ b/tests/fixtures/fake-clis.bash
@@ -46,6 +46,18 @@ if [[ "\${1:-}" == "--version" ]]; then
     echo "fake-$bin 0.0.1"
     exit 0
 fi
+EOF
+    if [[ "$bin" == "grok" ]]; then
+        cat >> "$FAKE_BIN_DIR/$bin" <<EOF
+# The real grok CLI answers a logged-out "grok models" with "You are not
+# authenticated." on stdout and exit 0, never a non-zero exit
+if [[ "\${1:-}" == "models" && "\${COUNCIL_FAKE_BEHAVIOR:-valid}" == "auth-failure" ]]; then
+    echo "You are not authenticated."
+    exit 0
+fi
+EOF
+    fi
+    cat >> "$FAKE_BIN_DIR/$bin" <<EOF
 case "\${COUNCIL_FAKE_BEHAVIOR:-valid}" in
     valid)          echo "$marker: deterministic answer" ;;
     empty)          ;;

--- a/tests/fixtures/fake-clis.bash
+++ b/tests/fixtures/fake-clis.bash
@@ -1,4 +1,4 @@
-# ABOUTME: Installs fake codex/agy CLI executables onto PATH for hermetic tests
+# ABOUTME: Installs fake codex/agy/grok CLI executables onto PATH for hermetic tests
 # ABOUTME: Behavior switches via COUNCIL_FAKE_BEHAVIOR; calls recorded as JSONL in COUNCIL_FAKE_STATE_DIR
 
 # Behaviors (COUNCIL_FAKE_BEHAVIOR):
@@ -23,7 +23,7 @@ install_fake_clis() {
     export FAKE_BIN_DIR COUNCIL_FAKE_STATE_DIR
 
     local bin
-    for bin in codex agy; do
+    for bin in codex agy grok; do
         write_fake_cli "$bin"
     done
     PATH="$FAKE_BIN_DIR:$PATH"

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -55,7 +55,7 @@ assert_blank() {
 path_without_clis() {
     local clean=$PATH
     local cli dir
-    for cli in codex gemini agy; do
+    for cli in codex gemini agy grok; do
         dir=$(dirname "$(command -v "$cli" 2>/dev/null)" 2>/dev/null || true)
         [[ -n "$dir" ]] || continue
         clean=$(echo "$clean" | tr ':' '\n' | grep -vF -- "$dir" | tr '\n' ':')


### PR DESCRIPTION
## What

Adds a `grok-cli` provider that drives xAI's Grok CLI (`grok`) in headless single-turn mode, gated on the binary being on `PATH` rather than an API key. A Grok CLI subscription can now answer the council with no `XAI_API_KEY` and no per-call cost, exactly the way `codex` and `antigravity` already do.

## Why

Today Grok is API-only, so users who have the Grok CLI logged in (subscription OAuth) still need a separate `console.x.ai` API key to include Grok. This closes that gap and makes the third first-party coding CLI a first-class council member.

## How it fits the existing design

It reuses the `SHADOW_PAIRS` machinery rather than adding a parallel code path. One entry, `grok:grok-cli`, propagates to:

- `discover_providers` (binary-gated, like codex/antigravity)
- `prefer_cli_over_api` (CLI preferred, API sibling dropped unless explicitly requested)
- `--list-available` shadow annotation
- CLI to API fallback (`api_sibling`)

Provider details, mirroring the codex/antigravity conventions:

- Invocation: `grok -p "<prompt>" --output-format plain -m "<model>" --sandbox read-only`
- Bounded by the same `perl alarm` `COUNCIL_TIMEOUT` wrapper
- Pins grok's built-in `read-only` sandbox as defense-in-depth against model-generated writes/shell
- Default model `grok-composer-2.5-fast`, overridable with `GROK_CLI_MODEL`
- Auth probe `grok models` gives it the same two-tier availability check as codex (`login status`)
- Image queries route to the `grok` API sibling (CLI cannot take an image), text-only when no key

## Tests

- The `fake-clis` fixture now installs a fake `grok`; new behavior, flag-ordering, sandbox-pin, timeout, and error tests mirror the codex/antigravity suites.
- `cli-providers.bats`: `shadow_origin grok`, `api_sibling grok-cli`, prefer-CLI drop, discovery include/exclude, `--providers=grok-cli`, gated real-CLI E2E.
- `check-status.bats`: provider count updated to `/7` with grok-cli's remediation and unauthed state.
- Full suite: **432 passing, 0 failing**. `shellcheck -x` clean on all touched scripts. Real-CLI E2E verified against a live Grok CLI login.

Docs updated: README (CLI providers section, quick start, vision routing), ARCHITECTURE (provider taxonomy, config, vision, file tree, diagram), CHANGELOG (Unreleased), TESTING (counts + fixture).