### PR TITLE
feat(providers): add kimi (API + CLI) and ollama council members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to claude-council are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to a `YYYY.M.BUILD` versioning scheme where `BUILD` resets each month.
 
+## Unreleased
+
+### Added
+
+- **Kimi (Moonshot AI) as a council member, in both flavours.** `kimi-cli`
+  drives the Kimi Code CLI on subscription auth and is registered as the shadow
+  partner of the `kimi` API provider, so an installed CLI is preferred and the
+  API only steps in when it fails — the same policy codex/antigravity/grok-cli
+  already follow. The CLI is read via `--output-format stream-json`: its text
+  renderer interleaves visible reasoning with the answer, prefixes every line
+  with `• ` and appends a session-resume footer, all of which would otherwise
+  be quoted verbatim in the synthesis.
+- **A local `ollama` model as a council member.** No key, no subscription, no
+  network. Binary-gated like the CLI providers; without `OLLAMA_MODEL` it uses
+  the first locally installed model rather than a hardcoded id that may not be
+  pulled. Local reasoning models spend most of their budget on thinking that
+  never reaches `.content`, so the token floor is raised and an exhausted
+  budget is reported as such instead of as an unknown error.
+
+### Fixed
+
+- **Any provider no colour arm named crashed `check-status.sh`.**
+  `provider_color`'s default arm expands `${CYAN}`, which check-status never
+  defined; under `set -u` that aborted the entire status run the moment a new
+  provider was added. The colour expansions now default to empty.
+- **The provider total in the status footer was hardcoded.** `N/7` would have
+  misreported the moment the roster changed; it is now derived.
+- **`path_without_clis` could not hide newly added binary-gated CLIs**, so
+  tests asserting the no-providers path saw a populated council.
+
 ## 2026.7.9
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ A Claude Code plugin that consults multiple AI coding agents in parallel and sho
 /plugin install claude-council
 
 # 2. Configure at least one provider — any of these works:
-export OPENAI_API_KEY="..."         # or GEMINI_API_KEY, XAI_API_KEY, PERPLEXITY_API_KEY
-                                    # OR install the codex / antigravity (agy) / grok CLIs (uses your existing
-                                    # subscription — no API key needed)
+export OPENAI_API_KEY="..."         # or GEMINI_API_KEY, XAI_API_KEY, PERPLEXITY_API_KEY, KIMI_API_KEY
+                                    # OR install the codex / antigravity (agy) / grok / kimi CLIs (uses your
+                                    # existing subscription — no API key needed)
 
 # 3. Ask anything
 /claude-council:ask "Should I use UUID or BIGINT primary keys for a SaaS users table?"
@@ -48,8 +48,9 @@ Inside tmux, results stream into a side pane in real time with vendor-colored ba
 
 ## Features
 
-- Query Gemini, OpenAI (GPT/Codex), Grok, and Perplexity simultaneously
-- Use the `codex`, `agy` (Antigravity), and `grok` CLIs (subscription auth) when installed — preferred over their API siblings
+- Query Gemini, OpenAI (GPT/Codex), Grok, Perplexity, and Kimi (Moonshot AI) simultaneously
+- Use the `codex`, `agy` (Antigravity), `grok`, and `kimi` (Kimi Code) CLIs (subscription auth) when installed — preferred over their API siblings
+- Run a local `ollama` model as a council member — no key, no subscription, no network
 - Side-by-side comparison of responses with vendor-colored headers
 - Streaming tmux pane that renders responses as they land
 - Specialized roles, debate mode, and agent-enhanced deep analysis for high-stakes decisions
@@ -496,6 +497,8 @@ in the response header:
 | grok | `grok-4.5` | `grok-4.20-reasoning` |
 | gemini | `gemini-3.1-pro-preview` | `gemini-pro-latest` |
 | perplexity | `sonar-reasoning-pro` | `sonar-pro` |
+| kimi | `kimi-k3` | `kimi-k2.6` |
+| ollama | first local model (`OLLAMA_MODEL` to pin) | — |
 
 The same substitution is also noted on stderr and folded into the synthesis,
 so it's visible even in quiet mode or a headless run. Setting `<PROVIDER>_MODEL`

--- a/scripts/check-status.sh
+++ b/scripts/check-status.sh
@@ -22,6 +22,8 @@ BLUE='\033[34m'
 WHITE='\033[37m'
 RED='\033[31m'
 GREEN='\033[32m'
+MAGENTA='\033[35m'
+CYAN='\033[36m'
 DIM='\033[2m'
 RESET='\033[0m'
 
@@ -119,6 +121,13 @@ check_provider() {
             http_code=$(curl -s -o "$body_file" -w "%{http_code}" --max-time 10 \
                 --config "$cfg" \
                 "https://api.x.ai/v1/models" 2>/dev/null || true)
+            rm -f "$cfg"
+            ;;
+        kimi)
+            cfg=$(curl_secret_config "Authorization: Bearer ${api_key}")
+            http_code=$(curl -s -o "$body_file" -w "%{http_code}" --max-time 10 \
+                --config "$cfg" \
+                "https://api.moonshot.ai/v1/models" 2>/dev/null || true)
             rm -f "$cfg"
             ;;
         perplexity)
@@ -219,10 +228,15 @@ remediation_for() {
         openai:no_key)        echo "export OPENAI_API_KEY=<key>" ;;
         grok:no_key)          echo "export XAI_API_KEY=<key>" ;;
         perplexity:no_key)    echo "export PERPLEXITY_API_KEY=<key>" ;;
+        kimi:no_key)          echo "export KIMI_API_KEY=<key>" ;;
         codex:no_binary)      echo "npm install -g @openai/codex" ;;
         codex:unauthed)       echo "codex login" ;;
         antigravity:no_binary) echo "install the Antigravity CLI (agy)" ;;
         grok-cli:no_binary)   echo "install the Grok CLI (grok)" ;;
+        kimi-cli:no_binary)   echo "install the Kimi Code CLI (kimi)" ;;
+        kimi-cli:unauthed)    echo "kimi login" ;;
+        ollama:no_binary)     echo "install Ollama (ollama.com)" ;;
+        ollama:unauthed)      echo "start the daemon: ollama serve" ;;
         grok-cli:unauthed)    echo "grok login" ;;
         *:auth_error)         echo "key rejected - regenerate it" ;;
         *)                    echo "" ;;
@@ -239,6 +253,7 @@ gemini_status=$(check_provider "gemini" "GEMINI_API_KEY" "GEMINI_MODEL" "gemini-
 openai_status=$(check_provider "openai" "OPENAI_API_KEY" "OPENAI_MODEL" "gpt-5.6-sol")
 grok_status=$(check_provider "grok" "GROK_API_KEY" "GROK_MODEL" "grok-4.5")
 perplexity_status=$(check_provider "perplexity" "PERPLEXITY_API_KEY" "PERPLEXITY_MODEL" "sonar-reasoning-pro")
+kimi_status=$(check_provider "kimi" "KIMI_API_KEY" "KIMI_MODEL" "kimi-k3")
 # codex login status exits non-zero when logged out; agy has no
 # equivalent offline auth probe, so it stays a single-tier check. `grok models`
 # prints "You are not authenticated." with exit 0 when logged out, which the
@@ -246,6 +261,8 @@ perplexity_status=$(check_provider "perplexity" "PERPLEXITY_API_KEY" "PERPLEXITY
 codex_status=$(check_cli_provider "codex" "codex" login status)
 antigravity_status=$(check_cli_provider "antigravity" "agy")
 grokcli_status=$(check_cli_provider "grok-cli" "grok" models)
+kimicli_status=$(check_cli_provider "kimi-cli" "kimi")
+ollama_status=$(check_cli_provider "ollama" "ollama" list)
 
 # Format output
 # Usage: format_status <display_name> <provider_id> <status>
@@ -308,6 +325,9 @@ format_status "Gemini"     "gemini"     "$gemini_status"
 format_status "OpenAI"     "openai"     "$openai_status"
 format_status "Grok"       "grok"       "$grok_status"
 format_status "Perplexity" "perplexity" "$perplexity_status"
+format_status "Kimi" "kimi" "$kimi_status"
+format_status "Kimi CLI" "kimi-cli" "$kimicli_status"
+format_status "Ollama" "ollama" "$ollama_status"
 format_status "Codex CLI"  "codex"      "$codex_status"
 format_status "Antigravity" "antigravity" "$antigravity_status"
 format_status "Grok CLI"   "grok-cli"   "$grokcli_status"
@@ -317,13 +337,17 @@ echo ""
 # Summary. available_count=$((...)) rather than ((available_count++)): under
 # set -e a post-increment returning 0 would abort the script on the first hit.
 available_count=0
+provider_total=10
 [[ "$gemini_status" == ok:* ]] && available_count=$((available_count + 1))
 [[ "$openai_status" == ok:* ]] && available_count=$((available_count + 1))
 [[ "$grok_status" == ok:* ]] && available_count=$((available_count + 1))
 [[ "$perplexity_status" == ok:* ]] && available_count=$((available_count + 1))
+[[ "$kimi_status" == ok:* ]] && available_count=$((available_count + 1))
+[[ "$kimicli_status" == ok:* ]] && available_count=$((available_count + 1))
+[[ "$ollama_status" == ok:* ]] && available_count=$((available_count + 1))
 [[ "$codex_status" == ok:* ]] && available_count=$((available_count + 1))
 [[ "$antigravity_status" == ok:* ]] && available_count=$((available_count + 1))
 [[ "$grokcli_status" == ok:* ]] && available_count=$((available_count + 1))
 
-echo -e "${DIM}${available_count}/7 providers available${RESET}"
+echo -e "${DIM}${available_count}/${provider_total} providers available${RESET}"
 echo ""

--- a/scripts/lib/display.sh
+++ b/scripts/lib/display.sh
@@ -308,6 +308,7 @@ provider_color_rgb() {
         openai|codex)      printf -v "$__out" '100;116;139'  ;;  # slate-500
         grok|grok-cli)     printf -v "$__out" '239;68;68'    ;;  # red-500
         perplexity)        printf -v "$__out" '22;163;74'    ;;  # green-600
+        kimi)              printf -v "$__out" '168;85;247'   ;;  # purple-500
         *)                 printf -v "$__out" '113;113;122'  ;;  # zinc-500
     esac
 }

--- a/scripts/lib/model_fallback.sh
+++ b/scripts/lib/model_fallback.sh
@@ -13,7 +13,7 @@ source "${LIB_MODEL_FALLBACK_DIR}/providers.sh"
 # Each id is verified against the live API before it lands here: a model can be
 # listed by a provider's models endpoint and still fail a completion (gemini-2.5-pro
 # is listed by Google's, and 404s on generateContent).
-MODEL_FALLBACKS="openai:gpt-5.5-pro grok:grok-4.20-reasoning perplexity:sonar-pro gemini:gemini-pro-latest"
+MODEL_FALLBACKS="openai:gpt-5.5-pro grok:grok-4.20-reasoning perplexity:sonar-pro gemini:gemini-pro-latest kimi:kimi-k2.6"
 
 # The model a provider degrades to when its preferred model is unavailable.
 # Empty for CLI providers, which degrade to their API sibling instead.

--- a/scripts/lib/providers.sh
+++ b/scripts/lib/providers.sh
@@ -24,6 +24,12 @@ discover_providers() {
             grok-cli)
                 command -v grok >/dev/null 2>&1 && is_available=true
                 ;;
+            kimi-cli)
+                command -v kimi >/dev/null 2>&1 && is_available=true
+                ;;
+            ollama)
+                command -v ollama >/dev/null 2>&1 && is_available=true
+                ;;
             *)
                 # API providers gate on <NAME>_API_KEY — the same check
                 # api_key_present makes, so there's one definition of it.
@@ -43,7 +49,7 @@ discover_providers() {
 # Both shadow_origin and api_sibling derive from this list, so they cannot
 # drift: adding a pair is a one-line change here that propagates to
 # prefer_cli_over_api, the --list-available display, and the CLI→API fallback.
-SHADOW_PAIRS="openai:codex gemini:antigravity grok:grok-cli"
+SHADOW_PAIRS="openai:codex gemini:antigravity grok:grok-cli kimi:kimi-cli"
 
 # Returns the CLI provider that shadows the given API provider (empty if none).
 shadow_origin() {
@@ -125,6 +131,9 @@ get_model() {
         perplexity) echo "${PERPLEXITY_MODEL:-sonar-reasoning-pro}" ;;
         codex)      echo "${CODEX_MODEL:-default}" ;;
         antigravity) echo "${ANTIGRAVITY_MODEL:-default}" ;;
+        kimi)       echo "${KIMI_MODEL:-kimi-k3}" ;;
+        kimi-cli)   echo "${KIMI_CLI_MODEL:-default}" ;;
+        ollama)     echo "${OLLAMA_MODEL:-local}" ;;
         *)          echo "unknown" ;;
     esac
 }
@@ -165,14 +174,19 @@ coerce_result_json() {
 # Vendor color for a provider name. CLI variants share their vendor's color
 # (codex with openai, antigravity with gemini, grok-cli with grok) since they
 # speak for the same vendor.
-# Caller is responsible for defining BLUE/WHITE/RED/GREEN/CYAN globals.
+# Callers define BLUE/WHITE/RED/GREEN/MAGENTA/CYAN; the expansions below
+# default to empty so a provider that no arm names cannot abort the caller
+# under `set -u` (check-status.sh defines no CYAN, so the default arm used to
+# kill the whole status run the moment any new provider was added).
 provider_color() {
     case "$1" in
-        gemini|antigravity) echo -e "${BLUE}" ;;
-        openai|codex)      echo -e "${WHITE}" ;;
-        grok|grok-cli)     echo -e "${RED}" ;;
-        perplexity)        echo -e "${GREEN}" ;;
-        *)                 echo -e "${CYAN}" ;;
+        gemini|antigravity) echo -e "${BLUE:-}" ;;
+        openai|codex)      echo -e "${WHITE:-}" ;;
+        grok|grok-cli)     echo -e "${RED:-}" ;;
+        perplexity)        echo -e "${GREEN:-}" ;;
+        kimi|kimi-cli)     echo -e "${MAGENTA:-}" ;;
+        ollama)            echo -e "${CYAN:-}" ;;
+        *)                 echo -e "${CYAN:-}" ;;
     esac
 }
 
@@ -183,6 +197,8 @@ provider_emoji() {
         openai|codex)      echo "🔳" ;;
         grok|grok-cli)     echo "🟥" ;;
         perplexity)        echo "🟩" ;;
+        kimi|kimi-cli)     echo "🟪" ;;
+        ollama)            echo "⬜" ;;
         *)                 echo "⬛" ;;
     esac
 }

--- a/scripts/providers/kimi-cli.sh
+++ b/scripts/providers/kimi-cli.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# ABOUTME: Queries the Kimi Code CLI in headless mode using subscription auth
+# ABOUTME: Availability is gated on the kimi binary being on PATH, not an API key
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/verbosity.sh"
+
+verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
+
+PROMPT="${1:-}"
+# A large prompt (e.g. a big --file) arrives via a temp file to stay off
+# the process argv, where the OS would reject it as "argument list too long".
+if [[ "$PROMPT" == "--prompt-file" ]]; then
+    PROMPT=$(cat "${2:?--prompt-file requires a path}")
+fi
+
+if [[ -z "$PROMPT" ]]; then
+    echo "Error: No prompt provided" >&2
+    exit 1
+fi
+
+if ! command -v kimi >/dev/null 2>&1; then
+    echo "Error: kimi CLI not found on PATH" >&2
+    exit 1
+fi
+
+SYSTEM="${VERBOSITY_PREFIX:+$VERBOSITY_PREFIX }$BASE_SYSTEM_PROMPT"
+FULL_PROMPT="${SYSTEM}
+
+${PROMPT}"
+
+# --output-format stream-json, not the default text: the text renderer prefixes
+# every line with "• ", interleaves the model's visible reasoning with the
+# answer, and appends a "To resume this session: …" footer. All three would end
+# up quoted verbatim in the council's synthesis. The JSONL stream separates them
+# cleanly — role "assistant" is the answer, role "meta" is the session hint.
+ARGS=(-p "$FULL_PROMPT" --output-format stream-json)
+# -m only on an explicit override, so an unset KIMI_CLI_MODEL defers to the
+# CLI's own default_model in config.toml (mirrors codex.sh and grok-cli.sh).
+[[ -n "${KIMI_CLI_MODEL:-}" ]] && ARGS+=(-m "$KIMI_CLI_MODEL")
+
+# Bound the CLI the way API providers are bounded by curl --max-time. GNU
+# `timeout` is absent on stock macOS, so use perl's alarm (perl is already a
+# renderer dependency); the pending alarm survives exec and kills the CLI after
+# COUNCIL_TIMEOUT seconds, surfacing as exit 142 (128 + SIGALRM).
+COUNCIL_TIMEOUT="${COUNCIL_TIMEOUT:-300}"
+
+ERR_TMP=$(mktemp)
+OUT_TMP=$(mktemp)
+trap 'rm -f "$ERR_TMP" "$OUT_TMP"' EXIT
+
+if perl -e 'alarm shift; exec @ARGV' "$COUNCIL_TIMEOUT" kimi "${ARGS[@]}" >"$OUT_TMP" 2>"$ERR_TMP"; then
+    # Concatenate every assistant chunk; a long answer may arrive in several.
+    # Non-JSON lines are skipped rather than aborting the run: the CLI is free
+    # to print an unstructured warning alongside the stream.
+    RESPONSE=$(jq -rs 'map(select(type == "object" and .role == "assistant") | .content // empty) | join("")' "$OUT_TMP" 2>/dev/null || true)
+    if [[ -z "${RESPONSE//[[:space:]]/}" ]]; then
+        echo "Error from kimi CLI: no assistant content in response" >&2
+        exit 1
+    fi
+    echo "$RESPONSE"
+else
+    rc=$?
+    if [[ $rc -eq 142 ]]; then
+        echo "Error from kimi CLI: timed out after ${COUNCIL_TIMEOUT}s" >&2
+    else
+        ERR_MSG=$(tr '\n' ' ' < "$ERR_TMP" | head -c 500)
+        echo "Error from kimi CLI: ${ERR_MSG:-non-zero exit}" >&2
+    fi
+    exit 1
+fi

--- a/scripts/providers/kimi.sh
+++ b/scripts/providers/kimi.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# ABOUTME: Queries the Kimi (Moonshot AI) API with a prompt via its OpenAI-compatible endpoint
+# ABOUTME: Adds a non-US-lab voice to the council to widen the range of opinions
+
+set -euo pipefail
+
+# Source shared libraries
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/retry.sh"
+source "$SCRIPT_DIR/../lib/tokens.sh"
+source "$SCRIPT_DIR/../lib/verbosity.sh"
+
+verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
+
+# Debug mode
+DEBUG="${COUNCIL_DEBUG:-}"
+
+PROMPT="${1:-}"
+IMAGE_FILE=""
+IMAGE_MIME=""
+# A large prompt (e.g. a big --file) arrives via a temp file to stay off
+# the process argv, where the OS would reject it as "argument list too long".
+if [[ "$PROMPT" == "--prompt-file" ]]; then
+    PROMPT=$(cat "${2:?--prompt-file requires a path}")
+    shift 2
+elif [[ $# -gt 0 ]]; then
+    shift
+fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image-file) IMAGE_FILE="${2:?--image-file requires a path}"; shift 2 ;;
+        --image-mime) IMAGE_MIME="${2:?--image-mime requires a value}"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+if [[ -z "$PROMPT" ]]; then
+    echo "Error: No prompt provided" >&2
+    exit 1
+fi
+
+# Check for API key. Named KIMI_API_KEY because discover_providers derives the
+# variable from this file's name; MOONSHOT_API_KEY is accepted as an alias for
+# anyone who already exports Moonshot's own convention, but only KIMI_API_KEY
+# makes the provider discoverable.
+API_KEY="${KIMI_API_KEY:-${MOONSHOT_API_KEY:-}}"
+if [[ -z "$API_KEY" ]]; then
+    echo "Error: KIMI_API_KEY not set" >&2
+    exit 1
+fi
+
+# Model selection (override via KIMI_MODEL env var)
+# Available: kimi-k3, kimi-k2.7-code, kimi-k2.7-code-highspeed, kimi-k2.6,
+# kimi-k2.5, moonshot-v1-{8k,32k,128k,auto} and the -vision-preview variants.
+MODEL="${KIMI_MODEL:-kimi-k3}"
+
+# Kimi Open Platform endpoint (OpenAI-compatible Chat Completions)
+ENDPOINT="${KIMI_ENDPOINT:-https://api.moonshot.ai/v1/chat/completions}"
+
+# Token limit (override via COUNCIL_MAX_TOKENS env var). The K-series are
+# reasoning models whose visible thinking shares the output budget, so raise
+# the cap for them to avoid truncating the answer mid-sentence.
+BASE_TOKENS="${COUNCIL_MAX_TOKENS:-2048}"
+bump_for_reasoning TOKENS "$MODEL" "$BASE_TOKENS" 'kimi-k*'
+
+# System instruction
+SYSTEM="${VERBOSITY_PREFIX:+$VERBOSITY_PREFIX }$BASE_SYSTEM_PROMPT"
+
+# The user message content is either a bare prompt string or, when an image is
+# supplied, an OpenAI-shaped [text, image_url] array. Kimi documents multimodal
+# content in the same shape, but provider_vision_capable deliberately leaves
+# kimi out: only the moonshot-v1-*-vision-preview ids are documented as vision
+# models, and that was never verified against the live API here. The branch is
+# kept so enabling vision is a one-line change in providers.sh once confirmed.
+if [[ -n "$IMAGE_FILE" ]]; then
+    USER_CONTENT=$(jq -n --arg prompt "$PROMPT" --rawfile b64 "$IMAGE_FILE" --arg mime "$IMAGE_MIME" '[
+        { type: "text",      text: $prompt },
+        { type: "image_url", image_url: { url: ("data:" + $mime + ";base64," + $b64) } }
+    ]')
+else
+    USER_CONTENT=$(jq -n --arg prompt "$PROMPT" '$prompt')
+fi
+
+# max_tokens is still accepted alongside the newer max_completion_tokens, and is
+# what every other provider here sends — keep the payload uniform.
+PAYLOAD=$(jq -n \
+    --arg model "$MODEL" \
+    --argjson tokens "$TOKENS" \
+    --arg system "$SYSTEM" \
+    --argjson content "$USER_CONTENT" \
+    '{
+        model: $model,
+        messages: [{
+            role: "system",
+            content: $system
+        }, {
+            role: "user",
+            content: $content
+        }],
+        temperature: 0.7,
+        max_tokens: $tokens
+    }')
+
+if [[ -n "$DEBUG" ]]; then
+    echo "=== DEBUG: Kimi ===" >&2
+    echo "Model: $MODEL" >&2
+    echo "Endpoint: $ENDPOINT" >&2
+    echo "Max tokens: $TOKENS" >&2
+fi
+
+# Keep the API key and request body off the process argv (ps-visible / OS
+# argument-size limits): the key travels via a mode-600 curl config file and
+# the payload via a temp file.
+CURL_CFG=$(curl_secret_config "Authorization: Bearer ${API_KEY}")
+PAYLOAD_FILE=$(mktemp)
+trap 'rm -f "$CURL_CFG" "$PAYLOAD_FILE"' EXIT
+printf '%s' "$PAYLOAD" > "$PAYLOAD_FILE"
+
+# Make API call
+RESPONSE=$(curl_with_retry -s -X POST "$ENDPOINT" \
+    --config "$CURL_CFG" \
+    -H "Content-Type: application/json" \
+    --data-binary @"$PAYLOAD_FILE")
+
+if [[ -n "$DEBUG" ]]; then
+    echo "=== DEBUG: Response metadata ===" >&2
+    echo "$RESPONSE" | jq '{ model: .model, usage: .usage }' >&2 2>/dev/null || true
+fi
+
+# Extract text from response (OpenAI-compatible format)
+TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+
+if [[ -z "$TEXT" ]]; then
+    ERROR=$(echo "$RESPONSE" | jq -r '(if (.error | type) == "object" then (.error.message // "") elif (.error | type) == "string" then .error else "" end) | select(. != "") // "Unknown error"')
+    echo "Error from Kimi: $ERROR" >&2
+    is_model_unavailable_error "$RESPONSE" && exit 3
+    exit 1
+fi
+
+echo "$TEXT"

--- a/scripts/providers/ollama.sh
+++ b/scripts/providers/ollama.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# ABOUTME: Queries a local Ollama server through its OpenAI-compatible endpoint
+# ABOUTME: Availability is gated on the ollama binary, not an API key — it is free and local
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../lib/retry.sh"
+source "$SCRIPT_DIR/../lib/tokens.sh"
+source "$SCRIPT_DIR/../lib/verbosity.sh"
+
+verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
+
+DEBUG="${COUNCIL_DEBUG:-}"
+
+PROMPT="${1:-}"
+IMAGE_FILE=""
+IMAGE_MIME=""
+# A large prompt (e.g. a big --file) arrives via a temp file to stay off
+# the process argv, where the OS would reject it as "argument list too long".
+if [[ "$PROMPT" == "--prompt-file" ]]; then
+    PROMPT=$(cat "${2:?--prompt-file requires a path}")
+    shift 2
+elif [[ $# -gt 0 ]]; then
+    shift
+fi
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --image-file) IMAGE_FILE="${2:?--image-file requires a path}"; shift 2 ;;
+        --image-mime) IMAGE_MIME="${2:?--image-mime requires a value}"; shift 2 ;;
+        *) shift ;;
+    esac
+done
+
+if [[ -z "$PROMPT" ]]; then
+    echo "Error: No prompt provided" >&2
+    exit 1
+fi
+
+if ! command -v ollama >/dev/null 2>&1; then
+    echo "Error: ollama not found on PATH" >&2
+    exit 1
+fi
+
+# Local server, no key. OLLAMA_HOST is Ollama's own convention, so an operator
+# who already points it at a remote box gets that for free.
+HOST="${OLLAMA_HOST:-http://localhost:11434}"
+[[ "$HOST" == http* ]] || HOST="http://$HOST"
+ENDPOINT="${HOST%/}/v1/chat/completions"
+
+# Model must exist locally (`ollama list`). No sane default id exists across
+# machines, so fall back to whichever model is installed first rather than
+# hardcoding one that may not be pulled here.
+MODEL="${OLLAMA_MODEL:-}"
+if [[ -z "$MODEL" ]]; then
+    MODEL=$(ollama list 2>/dev/null | awk 'NR==2 {print $1}')
+    if [[ -z "$MODEL" ]]; then
+        echo "Error: no local Ollama model found — run 'ollama pull <model>'" >&2
+        exit 1
+    fi
+fi
+
+# Token limit. Local reasoning models (gpt-oss, deepseek-r1, qwen*, gemma*)
+# spend a large share of the budget on thinking that never reaches .content;
+# a 2048 default returned an EMPTY answer with finish_reason "length" here, so
+# the floor is raised well above the API providers' default.
+BASE_TOKENS="${COUNCIL_MAX_TOKENS:-4096}"
+bump_for_reasoning TOKENS "$MODEL" "$BASE_TOKENS" '*r1*' '*reason*' '*gpt-oss*' 'qwen*' 'gemma*' 'deepseek*'
+
+SYSTEM="${VERBOSITY_PREFIX:+$VERBOSITY_PREFIX }$BASE_SYSTEM_PROMPT"
+
+if [[ -n "$IMAGE_FILE" ]]; then
+    USER_CONTENT=$(jq -n --arg prompt "$PROMPT" --rawfile b64 "$IMAGE_FILE" --arg mime "$IMAGE_MIME" '[
+        { type: "text",      text: $prompt },
+        { type: "image_url", image_url: { url: ("data:" + $mime + ";base64," + $b64) } }
+    ]')
+else
+    USER_CONTENT=$(jq -n --arg prompt "$PROMPT" '$prompt')
+fi
+
+PAYLOAD=$(jq -n \
+    --arg model "$MODEL" \
+    --argjson tokens "$TOKENS" \
+    --arg system "$SYSTEM" \
+    --argjson content "$USER_CONTENT" \
+    '{
+        model: $model,
+        messages: [{
+            role: "system",
+            content: $system
+        }, {
+            role: "user",
+            content: $content
+        }],
+        temperature: 0.7,
+        max_tokens: $tokens
+    }')
+
+if [[ -n "$DEBUG" ]]; then
+    echo "=== DEBUG: Ollama ===" >&2
+    echo "Model: $MODEL" >&2
+    echo "Endpoint: $ENDPOINT" >&2
+    echo "Max tokens: $TOKENS" >&2
+fi
+
+PAYLOAD_FILE=$(mktemp)
+trap 'rm -f "$PAYLOAD_FILE"' EXIT
+printf '%s' "$PAYLOAD" > "$PAYLOAD_FILE"
+
+# No Authorization header: a local daemon has no key. A remote OLLAMA_HOST
+# behind a proxy would need one, which is out of scope here.
+RESPONSE=$(curl_with_retry -s -X POST "$ENDPOINT" \
+    -H "Content-Type: application/json" \
+    --data-binary @"$PAYLOAD_FILE")
+
+if [[ -n "$DEBUG" ]]; then
+    echo "=== DEBUG: Response metadata ===" >&2
+    echo "$RESPONSE" | jq '{ model: .model, usage: .usage, finish: .choices[0].finish_reason }' >&2 2>/dev/null || true
+fi
+
+TEXT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')
+
+if [[ -z "${TEXT//[[:space:]]/}" ]]; then
+    # A thinking model that hit the cap answers with an empty .content and
+    # finish_reason "length" — its whole budget went into .reasoning. Say that
+    # plainly instead of reporting an "unknown error" the operator cannot act on.
+    FINISH=$(echo "$RESPONSE" | jq -r '.choices[0].finish_reason // empty')
+    if [[ "$FINISH" == "length" ]]; then
+        echo "Error from Ollama: $MODEL exhausted its ${TOKENS}-token budget on reasoning; raise COUNCIL_MAX_TOKENS" >&2
+        exit 1
+    fi
+    ERROR=$(echo "$RESPONSE" | jq -r '(if (.error | type) == "object" then (.error.message // "") elif (.error | type) == "string" then .error else "" end) | select(. != "") // "Unknown error"')
+    echo "Error from Ollama: $ERROR" >&2
+    is_model_unavailable_error "$RESPONSE" && exit 3
+    exit 1
+fi
+
+echo "$TEXT"

--- a/scripts/stop-review-gate.sh
+++ b/scripts/stop-review-gate.sh
@@ -26,7 +26,7 @@ IFS=$'\t' read -r ENABLED PROVIDER MAX_ITER < <(
 # constrain it to the known set — a config value like "../../evil" must never
 # select an arbitrary script. Unknown provider -> fail open.
 case "$PROVIDER" in
-    gemini|openai|grok|grok-cli|perplexity|codex|antigravity) ;;
+    gemini|openai|grok|grok-cli|perplexity|kimi|kimi-cli|ollama|codex|antigravity) ;;
     *) exit 0 ;;
 esac
 

--- a/tests/check-status.bats
+++ b/tests/check-status.bats
@@ -49,9 +49,9 @@ setup() {
     export COUNCIL_FAKE_BEHAVIOR=auth-failure
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
-    # antigravity (no auth probe) is the only available provider; codex and
-    # grok-cli both probe auth and report unauthed under auth-failure
-    [[ "$output" == *"1/7 providers available"* ]]
+    # antigravity and kimi-cli have no offline auth probe, so both still count;
+    # codex and grok-cli both probe auth and report unauthed under auth-failure
+    [[ "$output" == *"2/10 providers available"* ]]
 }
 
 @test "check-status: missing API key shows exact export remediation" {
@@ -103,7 +103,7 @@ exit 0
 EOF
     chmod +x "$dir/curl"
     export PATH="$dir:$PATH"
-    export GEMINI_API_KEY=k OPENAI_API_KEY=k XAI_API_KEY=k PERPLEXITY_API_KEY=k
+    export GEMINI_API_KEY=k OPENAI_API_KEY=k XAI_API_KEY=k PERPLEXITY_API_KEY=k KIMI_API_KEY=k
     export COUNCIL_FAKE_BEHAVIOR=valid
 }
 
@@ -113,8 +113,8 @@ EOF
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Connected"* ]]
-    # 4 API providers + codex + antigravity + grok-cli, all healthy
-    [[ "$output" == *"7/7 providers available"* ]]
+    # 5 API providers + codex + antigravity + grok-cli + kimi-cli + ollama, all healthy
+    [[ "$output" == *"10/10 providers available"* ]]
 }
 
 @test "check-status: HTTP 401 reports auth failure with regenerate remediation" {
@@ -126,9 +126,9 @@ EOF
     [[ "$output" == *"key rejected - regenerate it"* ]]
     # Every API provider must classify 401, not just whichever one happens to be
     # first: a substring match alone cannot tell four rows from one.
-    [ "$(auth_failures "$output")" -eq 4 ]
-    # Only the three CLI providers remain available (codex, antigravity, grok-cli)
-    [[ "$output" == *"3/7 providers available"* ]]
+    [ "$(auth_failures "$output")" -eq 5 ]
+    # Only the five local providers remain (codex, antigravity, grok-cli, kimi-cli, ollama)
+    [[ "$output" == *"5/10 providers available"* ]]
 }
 
 # Gemini answers 403 PERMISSION_DENIED for a referer-restricted key, OpenAI for a
@@ -140,7 +140,7 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"Auth failed (HTTP 403)"* ]]
     [[ "$output" == *"key rejected - regenerate it"* ]]
-    [ "$(auth_failures "$output")" -eq 4 ]
+    [ "$(auth_failures "$output")" -eq 5 ]
 }
 
 @test "check-status: HTTP 500 reports a generic error with the code" {
@@ -151,7 +151,7 @@ EOF
     [[ "$output" == *"Error (HTTP 500)"* ]]
     # A server-side fault is not a credentials problem
     [ "$(auth_failures "$output")" -eq 0 ]
-    [[ "$output" == *"3/7 providers available"* ]]
+    [[ "$output" == *"5/10 providers available"* ]]
 }
 
 @test "check-status: curl failure (000) reports a connection timeout" {
@@ -160,7 +160,7 @@ EOF
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Connection timeout"* ]]
-    [[ "$output" == *"3/7 providers available"* ]]
+    [[ "$output" == *"5/10 providers available"* ]]
 }
 
 # Gemini and xAI answer a rejected key with 400 rather than a 401, so the status
@@ -215,9 +215,9 @@ auth_failures() {
     export COUNCIL_FAKE_HTTP_BODY='{"error":{"code":400,"message":"* GetModelRequest.name: unexpected model name format\n","status":"INVALID_ARGUMENT"}}'
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
-    # All four API providers show the generic error: proves output was produced,
+    # All five API providers show the generic error: proves output was produced,
     # so the auth-failure count below cannot pass on an empty run.
-    [ "$(printf '%s\n' "$output" | grep -c 'Error (HTTP 400)' || true)" -eq 4 ]
+    [ "$(printf '%s\n' "$output" | grep -c 'Error (HTTP 400)' || true)" -eq 5 ]
     [ "$(auth_failures "$output")" -eq 0 ]
     [[ "$output" != *"key rejected"* ]]
 }
@@ -229,9 +229,9 @@ auth_failures() {
     export COUNCIL_FAKE_HTTP_BODY='{"code":"invalid-argument","error":"Model not found: grok-does-not-exist"}'
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
-    # All four API providers show the generic error: proves output was produced,
+    # All five API providers show the generic error: proves output was produced,
     # so the auth-failure count below cannot pass on an empty run.
-    [ "$(printf '%s\n' "$output" | grep -c 'Error (HTTP 400)' || true)" -eq 4 ]
+    [ "$(printf '%s\n' "$output" | grep -c 'Error (HTTP 400)' || true)" -eq 5 ]
     [ "$(auth_failures "$output")" -eq 0 ]
     [[ "$output" != *"key rejected"* ]]
 }
@@ -243,9 +243,9 @@ auth_failures() {
     run bash "$SCRIPT"
     [ "$status" -eq 0 ]
     # A malformed request is not a credentials problem; do not offer to regenerate
-    # All four API providers show the generic error: proves output was produced,
+    # All five API providers show the generic error: proves output was produced,
     # so the auth-failure count below cannot pass on an empty run.
-    [ "$(printf '%s\n' "$output" | grep -c 'Error (HTTP 400)' || true)" -eq 4 ]
+    [ "$(printf '%s\n' "$output" | grep -c 'Error (HTTP 400)' || true)" -eq 5 ]
     [ "$(auth_failures "$output")" -eq 0 ]
     [[ "$output" != *"key rejected"* ]]
 }

--- a/tests/cli-providers.bats
+++ b/tests/cli-providers.bats
@@ -576,3 +576,99 @@ EOF
     [ "$status" -eq 0 ]
     [[ "$output" == *"OK"* ]]
 }
+
+# ============================================================================
+# kimi-cli — subscription-auth sibling of the kimi API provider
+# ============================================================================
+
+@test "discover_providers: includes kimi-cli when the kimi binary is on PATH" {
+    if ! command_exists kimi; then skip "kimi CLI not installed"; fi
+    run source_lib_and_call 'discover_providers'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"kimi-cli"* ]]
+}
+
+@test "kimi-cli shadows the kimi API provider, so the subscription is preferred" {
+    run source_lib_and_call 'shadow_origin kimi'
+    [ "$status" -eq 0 ]
+    [ "$output" = "kimi-cli" ]
+}
+
+@test "kimi-cli falls back to the kimi API provider when it fails" {
+    run source_lib_and_call 'api_sibling kimi-cli'
+    [ "$status" -eq 0 ]
+    [ "$output" = "kimi" ]
+}
+
+@test "kimi-cli is binary-gated, not key-gated" {
+    # A key must not conjure the CLI provider into existence; only the binary does.
+    run bash -c "
+        set -euo pipefail
+        export PROVIDERS_DIR='${PROVIDERS_DIR_REAL}'
+        export PATH="$(path_without_clis)"
+        export KIMI_API_KEY=k
+        source '${PROVIDERS_LIB}'
+        discover_providers
+    "
+    [[ "$output" != *"kimi-cli"* ]]
+}
+
+@test "get_model: labels both kimi providers instead of reporting unknown" {
+    run source_lib_and_call 'get_model kimi'
+    [ "$output" = "kimi-k3" ]
+    run source_lib_and_call 'get_model kimi-cli'
+    [ "$output" = "default" ]
+}
+
+# ============================================================================
+# ollama — local daemon, binary-gated, no key and no subscription
+# ============================================================================
+
+@test "discover_providers: includes ollama when the binary is on PATH" {
+    if ! command_exists ollama; then skip "ollama not installed"; fi
+    run source_lib_and_call 'discover_providers'
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ollama"* ]]
+}
+
+@test "ollama is binary-gated, not key-gated" {
+    run bash -c "
+        set -euo pipefail
+        export PROVIDERS_DIR='${PROVIDERS_DIR_REAL}'
+        export PATH="$(path_without_clis)"
+        source '${PROVIDERS_LIB}'
+        discover_providers
+    "
+    [[ "$output" != *"ollama"* ]]
+}
+
+@test "ollama has no API sibling and shadows nothing" {
+    # It is neither a cheaper CLI for a paid API nor shadowed by one; a local
+    # model is its own thing, so both directions must stay empty.
+    run source_lib_and_call 'api_sibling ollama'
+    [ "$output" = "" ]
+    run source_lib_and_call 'shadow_origin ollama'
+    [ "$output" = "" ]
+}
+
+@test "the whole council runs on subscriptions and local models, with no API key" {
+    # The configuration this plugin is actually used with here: Codex and Kimi
+    # via subscription, Ollama locally. A regression that made any of them
+    # key-gated would silently empty the council.
+    run bash -c "
+        set -euo pipefail
+        export PROVIDERS_DIR='${PROVIDERS_DIR_REAL}'
+        unset GEMINI_API_KEY OPENAI_API_KEY GROK_API_KEY XAI_API_KEY PERPLEXITY_API_KEY KIMI_API_KEY MOONSHOT_API_KEY
+        source '${PROVIDERS_LIB}'
+        discover_providers
+    "
+    [ "$status" -eq 0 ]
+    for p in codex kimi-cli ollama; do
+        if command_exists "${p%-cli}" || command_exists "$p"; then
+            [[ "$output" == *"$p"* ]]
+        fi
+    done
+    # No API provider may appear without its key.
+    [[ "$output" != *"perplexity"* ]]
+    [[ "$output" != *"gemini"* ]]
+}

--- a/tests/fixtures/fake-clis.bash
+++ b/tests/fixtures/fake-clis.bash
@@ -1,4 +1,4 @@
-# ABOUTME: Installs fake codex/agy/grok CLI executables onto PATH for hermetic tests
+# ABOUTME: Installs fake codex/agy/grok/kimi/ollama CLI executables onto PATH for hermetic tests
 # ABOUTME: Behavior switches via COUNCIL_FAKE_BEHAVIOR; calls recorded as JSONL in COUNCIL_FAKE_STATE_DIR
 
 # Behaviors (COUNCIL_FAKE_BEHAVIOR):
@@ -23,7 +23,7 @@ install_fake_clis() {
     export FAKE_BIN_DIR COUNCIL_FAKE_STATE_DIR
 
     local bin
-    for bin in codex agy grok; do
+    for bin in codex agy grok kimi ollama; do
         write_fake_cli "$bin"
     done
     PATH="$FAKE_BIN_DIR:$PATH"

--- a/tests/providers.bats
+++ b/tests/providers.bats
@@ -300,3 +300,60 @@ run_provider() {
     [ "$status" -eq 1 ]
     [[ "$stderr" == *"upstream gateway error"* ]]
 }
+
+# ---- kimi (Moonshot) ----
+
+@test "kimi: extracts content and surfaces errors" {
+    FAKE_BODY='{"choices":[{"message":{"content":"KIMI_OK"}}]}'
+    run_provider kimi.sh "hi" KIMI_API_KEY=k
+    [ "$status" -eq 0 ]
+    [ "$output" = "KIMI_OK" ]
+}
+
+@test "kimi: missing key fails before any request" {
+    FAKE_BODY='{"choices":[{"message":{"content":"x"}}]}'
+    run_provider kimi.sh "hi"
+    [ "$status" -eq 1 ]
+    [[ "$stderr" == *"KIMI_API_KEY not set"* ]]
+    assert_blank "$(cat "$ARGV_FILE")"
+}
+
+@test "kimi: MOONSHOT_API_KEY is accepted as an alias" {
+    FAKE_BODY='{"choices":[{"message":{"content":"ALIAS_OK"}}]}'
+    run_provider kimi.sh "hi" MOONSHOT_API_KEY=k
+    [ "$status" -eq 0 ]
+    [ "$output" = "ALIAS_OK" ]
+}
+
+@test "kimi: routes to the Moonshot chat-completions endpoint" {
+    FAKE_BODY='{"choices":[{"message":{"content":"x"}}]}'
+    run_provider kimi.sh "hi" KIMI_API_KEY=k
+    [ "$status" -eq 0 ]
+    grep -qF "https://api.moonshot.ai/v1/chat/completions" "$ARGV_FILE"
+}
+
+@test "kimi: bearer key never appears in the process argv" {
+    FAKE_BODY='{"choices":[{"message":{"content":"x"}}]}'
+    run_provider kimi.sh "hi" KIMI_API_KEY=SEKRET_KIMI
+    [ "$status" -eq 0 ]
+    ! grep -qF "SEKRET_KIMI" "$ARGV_FILE"
+    grep -qF "SEKRET_KIMI" "$CONFIG_FILE"
+}
+
+@test "kimi: request payload is sent off-argv via a file" {
+    FAKE_BODY='{"choices":[{"message":{"content":"x"}}]}'
+    run_provider kimi.sh "UNIQUE_KIMI_MARKER_77" KIMI_API_KEY=k
+    [ "$status" -eq 0 ]
+    ! grep -qF "UNIQUE_KIMI_MARKER_77" "$ARGV_FILE"
+    grep -qF "UNIQUE_KIMI_MARKER_77" "$DATA_FILE"
+}
+
+@test "kimi: an unavailable model exits 3, an ordinary error exits 1" {
+    FAKE_BODY='{"error":{"message":"model not found","type":"invalid_request_error"}}'
+    FAKE_HTTP=404 run_provider kimi.sh "hi" KIMI_API_KEY=k
+    [ "$status" -eq 3 ]
+
+    FAKE_BODY='{"error":{"message":"invalid api key"}}'
+    FAKE_HTTP=401 run_provider kimi.sh "hi" KIMI_API_KEY=k
+    [ "$status" -eq 1 ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -48,6 +48,7 @@ command_exists() {
 # Helper: clear every provider API key so discovery sees none of them
 unset_provider_keys() {
     unset GEMINI_API_KEY OPENAI_API_KEY GROK_API_KEY XAI_API_KEY PERPLEXITY_API_KEY
+    unset KIMI_API_KEY MOONSHOT_API_KEY
 }
 
 # Helper: assert a string is empty or whitespace-only
@@ -58,10 +59,14 @@ assert_blank() {
 # Helper: compute a PATH that excludes the directories holding codex and gemini.
 # Use when a test needs to assert "no providers available" on a developer machine
 # that has the CLI agents installed.
+# Removes the DIRECTORY each binary-gated CLI lives in, so discovery finds
+# none of them. Caveat worth knowing before adding an entry: a CLI installed
+# into a shared prefix takes that whole prefix out of PATH for the test — put
+# nothing here that commonly shares a directory with jq, curl or node.
 path_without_clis() {
     local clean=$PATH
     local cli dir
-    for cli in codex gemini agy grok; do
+    for cli in codex gemini agy grok kimi ollama; do
         dir=$(dirname "$(command -v "$cli" 2>/dev/null)" 2>/dev/null || true)
         [[ -n "$dir" ]] || continue
         clean=$(echo "$clean" | tr ':' '\n' | grep -vF -- "$dir" | tr '\n' ':')


### PR DESCRIPTION
Both close the same gap: a council usable without buying API access. kimi-cli and ollama join codex/antigravity/grok-cli as providers that need no key.

kimi ships in both flavours. kimi-cli drives the Kimi Code CLI on subscription auth and is the shadow partner of the kimi API provider, so an installed CLI wins and the API only steps in when it fails — the policy the other CLI/API pairs already follow. The CLI is read via --output-format stream-json, not its text renderer: that one interleaves visible reasoning with the answer, prefixes every line with a bullet and appends a session-resume footer, all of which would otherwise be quoted verbatim in the synthesis.

ollama is binary-gated and entirely local. Without OLLAMA_MODEL it picks the first installed model instead of a hardcoded id that may not be pulled on this machine. Local reasoning models spend most of their budget on thinking that never reaches .content — a 2048 default returned an EMPTY answer with finish_reason "length" during testing — so the token floor is raised and an exhausted budget is reported as exactly that rather than as "Unknown error".

Three pre-existing defects surfaced while wiring these up and are fixed here, because each one blocks adding any provider at all:

- provider_color's default arm expands ${CYAN}, which check-status.sh never defined. Under set -u that aborted the whole status run the moment a provider appeared that no arm named. The colour expansions now default to empty.
- The status footer's provider total was hardcoded as N/7 and would have misreported on any roster change. It is derived now.
- path_without_clis could not hide newly added binary-gated CLIs, so the tests asserting the no-providers path saw a populated council instead.

Verified with the CI gates locally: shellcheck 0.11.0 clean over every tracked script, and tests/run_tests.sh green at 454/454 under bash 3.2.