### PR TITLE
fix: Gemini renders as null/Unknown error on Windows (jq CRLF key-miss)

### DIFF
--- a/scripts/format-output.sh
+++ b/scripts/format-output.sh
@@ -122,9 +122,12 @@ format_output() {
         return 0
     fi
 
-    # Get providers list from round1
+    # Get providers list from round1. Strip \r: jq's Windows build can
+    # CRLF-translate its stdout when piped rather than attached to a real
+    # console, and an unstripped \r riding along on the first provider name
+    # turns `.round1["gemini\r"]` into a silent key-miss (null) below.
     local providers
-    providers=$(echo "$json" | jq -r '.round1 | keys[]')
+    providers=$(echo "$json" | jq -r '.round1 | keys[]' | tr -d '\r')
 
     # If quiet mode, skip individual responses
     if [[ "$quiet" != "true" ]]; then

--- a/scripts/providers/gemini.sh
+++ b/scripts/providers/gemini.sh
@@ -64,22 +64,29 @@ bump_for_reasoning TOKENS "$MODEL" "$BASE_TOKENS" 'gemini-3*' '*thinking*' 'gemi
 
 SYSTEM="${VERBOSITY_PREFIX:+$VERBOSITY_PREFIX }$BASE_SYSTEM_PROMPT"
 
+# Cap on internal "thinking" tokens (override via GEMINI_THINKING_BUDGET). A
+# reasoning model can otherwise burn the entire maxOutputTokens allowance on
+# invisible chain-of-thought and return an empty answer with no error field —
+# capping thinking guarantees room is left for the actual response, and tends
+# to cut the tail latency that causes request timeouts too.
+THINKING_BUDGET="${GEMINI_THINKING_BUDGET:-8192}"
+
 # Build request payload
 if [[ -n "$IMAGE_FILE" ]]; then
     PAYLOAD=$(jq -n --arg prompt "$PROMPT" --argjson tokens "$TOKENS" --arg system "$SYSTEM" \
-        --rawfile b64 "$IMAGE_FILE" --arg mime "$IMAGE_MIME" '{
+        --rawfile b64 "$IMAGE_FILE" --arg mime "$IMAGE_MIME" --argjson thinking "$THINKING_BUDGET" '{
         system_instruction: { parts: [{ text: $system }] },
         contents: [{ parts: [
             { text: $prompt },
             { inlineData: { mimeType: $mime, data: $b64 } }
         ]}],
-        generationConfig: { temperature: 0.7, maxOutputTokens: $tokens }
+        generationConfig: { temperature: 0.7, maxOutputTokens: $tokens, thinkingConfig: { thinkingBudget: $thinking } }
     }')
 else
-    PAYLOAD=$(jq -n --arg prompt "$PROMPT" --argjson tokens "$TOKENS" --arg system "$SYSTEM" '{
+    PAYLOAD=$(jq -n --arg prompt "$PROMPT" --argjson tokens "$TOKENS" --arg system "$SYSTEM" --argjson thinking "$THINKING_BUDGET" '{
         system_instruction: { parts: [{ text: $system }] },
         contents: [{ parts: [{ text: $prompt }] }],
-        generationConfig: { temperature: 0.7, maxOutputTokens: $tokens }
+        generationConfig: { temperature: 0.7, maxOutputTokens: $tokens, thinkingConfig: { thinkingBudget: $thinking } }
     }')
 fi
 
@@ -97,11 +104,25 @@ RESPONSE=$(curl_with_retry -s -X POST "$ENDPOINT" \
     -H "Content-Type: application/json" \
     --data-binary @"$PAYLOAD_FILE")
 
-# Extract text from response
-TEXT=$(echo "$RESPONSE" | jq -r '.candidates[0].content.parts[0].text // empty')
+# Extract text from response. Join every text part rather than assuming the
+# answer sits in parts[0] — a thought-signature part can precede it.
+TEXT=$(echo "$RESPONSE" | jq -r '[.candidates[0].content.parts[]? | select(.text) | .text] | join("") // empty')
 
 if [[ -z "$TEXT" ]]; then
-    ERROR=$(echo "$RESPONSE" | jq -r '.error.message // "Unknown error"')
+    # A well-formed HTTP error carries .error.message. A 200 with no visible
+    # text (most often the model spending its whole token budget on internal
+    # reasoning, or a safety block) carries neither .error nor .candidates —
+    # surface finishReason/blockReason/token usage instead of a bare
+    # "Unknown error" so the real cause is visible in logs.
+    ERROR=$(echo "$RESPONSE" | jq -r '
+        if (.error.message // "") != "" then .error.message
+        elif (.promptFeedback.blockReason // "") != "" then
+            "prompt blocked (" + .promptFeedback.blockReason + ")"
+        elif (.candidates[0].finishReason // "") != "" then
+            "empty response (finishReason: " + .candidates[0].finishReason +
+            ", thoughts tokens: " + ((.usageMetadata.thoughtsTokenCount // 0) | tostring) +
+            "/" + ((.usageMetadata.totalTokenCount // 0) | tostring) + ")"
+        else "Unknown error" end')
     echo "Error from Gemini: $ERROR" >&2
     is_model_unavailable_error "$RESPONSE" && exit 3
     exit 1


### PR DESCRIPTION
fix: Gemini responses render as `null`/"Unknown error" on Windows

## What's broken

On Windows, `--debate` (and plain) council queries involving Gemini
consistently render the Gemini slot as an opaque `null` (round 1) or
`Error: Unknown error` (round 2 rebuttal) — even when the API call actually
succeeded with a full, valid answer.

## Root cause

`scripts/format-output.sh` builds the provider list with:

```sh
providers=$(echo "$json" | jq -r '.round1 | keys[]')
```

On Windows, the `jq` binary is a native PE executable. When its stdout is
piped (not attached to a console) it CRLF-translates its output, so
`keys[]` for `{"gemini": …, "openai": …}` comes out as `gemini\r\nopenai\n`
rather than `gemini\nopenai\n`. Command substitution only strips the
*trailing* newline, so the *first* key keeps a stray `\r` glued to it.

The `for provider in $providers` loop then does:

```sh
entry=$(echo "$json" | jq -c ".round1[\"${provider}\"]")
```

`.round1["gemini\r"]` doesn't match the real `"gemini"` key, jq returns
`null`, and `render_response` falls through to its "unparseable" branch,
printing the literal string `null` — discarding a perfectly good answer.
Because `gemini` sorts alphabetically before every other current provider,
it's always the one that eats the stray `\r`, which is why this reads as
"Gemini is broken" rather than a display bug.

Reproduced deterministically against a static saved council JSON (no live
API involved) — see the diff's comment for the exact repro.

## Fix

- `format-output.sh`: pipe the provider-key extraction through `tr -d '\r'`.
- `providers/gemini.sh` (smaller, secondary hardening): set
  `generationConfig.thinkingConfig.thinkingBudget` (default 8192, override
  via `GEMINI_THINKING_BUDGET`) so `gemini-3.1-pro-preview` can't burn its
  entire `maxOutputTokens` allowance on invisible reasoning and come back
  with a genuinely empty answer. When text is still empty, the error message
  now surfaces `finishReason` / `promptFeedback.blockReason` / token usage
  instead of a bare "Unknown error". Also extracts text by joining every
  `parts[]` entry instead of assuming the answer is `parts[0]`.

## Verification

- Isolated repro: re-ran `format-output.sh` against a saved council JSON
  known to contain a valid `round1.gemini` response — before the fix it
  printed `null`, after the fix it prints the real answer.
- Live end-to-end: `run-council.sh --debate --providers=gemini,openai` runs
  cleanly through both rounds post-fix.
- Confirmed via a direct API call that `gemini-3.1-pro-preview` accepts
  `thinkingConfig.thinkingBudget` (HTTP 200).

No other file in `scripts/` uses the same `keys[] | for provider in $(...)`
pattern, so this is the only spot that needed the `tr -d '\r'` guard.
