### PR TITLE
ci: run the bats suite on windows-latest

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,8 +11,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # Git Bash on the Windows runner, so every step below runs the same shell
+    # the plugin runs under there.
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
 
@@ -24,7 +29,15 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install bats-core jq
 
+      # Git for Windows ships bash, curl and perl; jq and bats do not come with it.
+      - name: Install dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          choco install jq -y --no-progress
+          npm install -g bats
+
       # macOS runners ship bash 3.2 as /bin/bash — the plugin's compat target.
+      # Windows resolves /bin/bash to Git Bash.
       - name: Show bash version
         run: /bin/bash --version | head -1
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
+    # Windows spawns processes slowly enough that the suite takes many times its
+    # Linux wall time; the cap turns a hung run into a failure, not a six-hour job.
+    timeout-minutes: 60
     # Git Bash on the Windows runner, so every step below runs the same shell
     # the plugin runs under there.
     defaults:
@@ -41,7 +44,11 @@ jobs:
       - name: Show bash version
         run: /bin/bash --version | head -1
 
+      # A hung test fails after two minutes instead of stalling the job (bats
+      # 1.7+; older builds ignore the variable).
       - name: Run bats suite
+        env:
+          BATS_TEST_TIMEOUT: 120
         run: bash tests/run_tests.sh
 
   shellcheck:

--- a/TESTING.md
+++ b/TESTING.md
@@ -50,7 +50,7 @@ bats --verbose-run tests/cache.bats
 | `query-council.bats` | 33 tests | argument parsing, error cases, flags, local-council fallback hint, hyphenated provider names (env-var prefix derivation), model-fallback wrapper (preferred-then-fallback retry, cached-verdict skip, explicit `<PROVIDER>_MODEL` opt-out, no verdict remembered when the fallback also fails), round 2 and CLI-sibling fallback carrying `model_fallback`, the pane's retry offer (offer file contents, r re-queries only the failed providers and clears the error list, expiry, pane closed at the offer, `COUNCIL_RETRY_WAIT=0`, no pane, a leaked non-watch-dir `COUNCIL_PANE_DIR` ignored) |
 | `argmax.bats` | 4 tests | large response/prompt/debate-round-2 round-trip through final JSON (MSYS ARG_MAX marshalling guard) |
 | `fake-clis.bats` | 62 tests | fixture self-checks, codex.sh/antigravity.sh/grok-cli.sh/kimi-cli.sh/ollama.sh against fake binaries (kimi-cli: stream-json parsing, dirty-stream tolerance, array-form content, tool-call narration excluded, no-tools agent pinned; ollama: daemon-down diagnostic; antigravity: the argv spill past `COUNCIL_ARGV_LIMIT`, its dedicated `--add-dir` directory, the guard and system prompt staying on argv while only the question is written out, cleanup after a failing CLI and under a spaced `TMPDIR`; `COUNCIL_PROVIDERS` roster precedence and its agreement with `--list-default` and `--list-available`; per-CLI timeout bounds via `COUNCIL_CLI_TIMEOUT`, and that a timeout reports only the timeout, never the shell's own signal notice) |
-| `format-output.bats` | 13 tests | defensive parsing: empty/missing/non-string responses, raw preservation, CLI→API fallback-note rendering, model-fallback note (preferred model named, absent when unset) |
+| `format-output.bats` | 14 tests | defensive parsing: empty/missing/non-string responses, raw preservation, CLI→API fallback-note rendering, model-fallback note (preferred model named, absent when unset), the first provider key surviving CRLF from a Windows jq |
 | `prompts.bats` | 11 tests | template loading, {{VAR}} interpolation, role-injection rendering |
 | `agent-analysis.bats` | 11 tests | validate-analysis.sh as the executable mirror of the agent-analysis schema, kept in sync with it |
 | `check-status.bats` | 27 tests | two-tier CLI availability, remediation strings, HTTP probe branches (401/403/500/000), rejected-key classification (Gemini/xAI answer a bad key with 400, not 401) and its false-positive guards (a typo'd model is not a bad key), transfer-failure exit codes, curl writing nothing, unusable jq, Perplexity's minimum max_tokens, `-X POST` and `--max-time` on every probe, temp-file cleanup, keys off the curl argv, ms clock |
@@ -65,7 +65,7 @@ bats --verbose-run tests/cache.bats
 | `retry.bats` | 11 tests | curl_with_retry backoff + status handling, curl_secret_config off-argv config file, ensure_error_body http_status stamping (object and string `.error`, Gemini's string `.error.status` left alone, synthesised message, 200 passthrough) |
 | `model_fallback.bats` | 29 tests | is_model_unavailable_error classifier (positive/negative fixtures from real vendor bodies), model_fallback_for pairs and the invariant that no provider degrades to the model it already prefers, verdict cache (TTL, provider+model+key scoping, corrupt/fractional-timestamp guards), model_fallback_key_hash, gated real-API test (default model or its fallback answers, end to end) |
 
-**Total: 543 tests** across 24 `.bats` files.
+**Total: 544 tests** across 24 `.bats` files.
 
 ### Hermetic CLI Fixture
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -64,8 +64,9 @@ bats --verbose-run tests/cache.bats
 | `release.bats` | 5 tests | release.sh version bump/commit/tag, staged-index guard, green-suite gate |
 | `retry.bats` | 11 tests | curl_with_retry backoff + status handling, curl_secret_config off-argv config file, ensure_error_body http_status stamping (object and string `.error`, Gemini's string `.error.status` left alone, synthesised message, 200 passthrough) |
 | `model_fallback.bats` | 29 tests | is_model_unavailable_error classifier (positive/negative fixtures from real vendor bodies), model_fallback_for pairs and the invariant that no provider degrades to the model it already prefers, verdict cache (TTL, provider+model+key scoping, corrupt/fractional-timestamp guards), model_fallback_key_hash, gated real-API test (default model or its fallback answers, end to end) |
+| `deadline.bats` | 4 tests | run_with_deadline: the caller's stdin reaches the command, the command's own status passes through, status 143 at the deadline, no watchdog outliving a fast call |
 
-**Total: 544 tests** across 24 `.bats` files.
+**Total: 548 tests** across 25 `.bats` files.
 
 ### Hermetic CLI Fixture
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,8 +54,8 @@ bats --verbose-run tests/cache.bats
 | `prompts.bats` | 11 tests | template loading, {{VAR}} interpolation, role-injection rendering |
 | `agent-analysis.bats` | 11 tests | validate-analysis.sh as the executable mirror of the agent-analysis schema, kept in sync with it |
 | `check-status.bats` | 27 tests | two-tier CLI availability, remediation strings, HTTP probe branches (401/403/500/000), rejected-key classification (Gemini/xAI answer a bad key with 400, not 401) and its false-positive guards (a typo'd model is not a bad key), transfer-failure exit codes, curl writing nothing, unusable jq, Perplexity's minimum max_tokens, `-X POST` and `--max-time` on every probe, temp-file cleanup, keys off the curl argv, ms clock |
-| `jobs.bats` | 17 tests | job store, --async lifecycle, --result/--jobs/--cancel, self-ignoring cache dir |
-| `stop-gate.bats` | 10 tests | opt-in gating, loop guards, BLOCK verdict, fail-open |
+| `jobs.bats` | 18 tests | job store, --async lifecycle, --result/--jobs/--cancel (incl. the worker tree dying when jq emits CRLF), self-ignoring cache dir |
+| `stop-gate.bats` | 11 tests | opt-in gating, loop guards, BLOCK verdict, fail-open, config/event reads surviving CRLF from a Windows jq |
 | `theme.bats` | 24 tests | terminal theme detection, theme-aware emphasis + muted-text (faint/gray) rendering |
 | `providers.bats` | 49 tests | API provider payloads (gemini, openai, grok, perplexity, kimi; gemini's multi-part text join, empty-200 diagnostics and the opt-in thinking cap), the default model each one queries and the reasoning-token cap its id earns (the `*-latest` aliases included), response parsing, endpoint routing, secret/payload hygiene, vision image injection (gemini inlineData, openai input_image/image_url, grok/perplexity image_url), model-unavailable exit-3 classification per provider (grok 403 region block, openai/gemini/perplexity 404/400) vs. ordinary errors (401/500) still exiting 1, bare-string `.error` extraction without crashing, the temperature Moonshot's models accept, and a gated real-endpoint acceptance check per provider |
 | `image.bats` | 9 tests | --image validation (missing/bad-type/oversize), vision routing, CLI→sibling routing (only when the sibling can see), non-vision text-only tag, base64 never in the cache |
@@ -66,7 +66,7 @@ bats --verbose-run tests/cache.bats
 | `model_fallback.bats` | 29 tests | is_model_unavailable_error classifier (positive/negative fixtures from real vendor bodies), model_fallback_for pairs and the invariant that no provider degrades to the model it already prefers, verdict cache (TTL, provider+model+key scoping, corrupt/fractional-timestamp guards), model_fallback_key_hash, gated real-API test (default model or its fallback answers, end to end) |
 | `deadline.bats` | 4 tests | run_with_deadline: the caller's stdin reaches the command, the command's own status passes through, status 143 at the deadline, no watchdog outliving a fast call |
 
-**Total: 548 tests** across 25 `.bats` files.
+**Total: 550 tests** across 25 `.bats` files.
 
 ### Hermetic CLI Fixture
 

--- a/scripts/lib/deadline.sh
+++ b/scripts/lib/deadline.sh
@@ -3,7 +3,8 @@
 # ABOUTME: Portable to macOS and Git Bash; exit 143 means the deadline ended it
 
 # Run the command after the seconds argument, ending it once the deadline
-# passes. Stdout and stderr pass through untouched; the status is the command's
+# passes. Stdin, stdout and stderr pass through untouched (a background job
+# would otherwise read /dev/null on bash 3.2); the status is the command's
 # own, or 143 (128 + SIGTERM) when the watchdog killed it. GNU `timeout` is
 # absent on stock macOS and on Git Bash, and a perl alarm never reaches the
 # child on Windows, where perl emulates exec by spawning and waiting. The
@@ -16,7 +17,7 @@ run_with_deadline() {
     local secs="$1"
     shift
     local pid rc=0
-    "$@" &
+    "$@" <&0 &
     pid=$!
     (
         t="$secs"

--- a/scripts/lib/deadline.sh
+++ b/scripts/lib/deadline.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# ABOUTME: Runs a command under a wall-clock deadline without GNU timeout
+# ABOUTME: Portable to macOS and Git Bash; exit 143 means the deadline ended it
+
+# Run the command after the seconds argument, ending it once the deadline
+# passes. Stdout and stderr pass through untouched; the status is the command's
+# own, or 143 (128 + SIGTERM) when the watchdog killed it. GNU `timeout` is
+# absent on stock macOS and on Git Bash, and a perl alarm never reaches the
+# child on Windows, where perl emulates exec by spawning and waiting. The
+# watchdog ticks once a second and leaves as soon as the command is gone, so no
+# sleeping process outlives a fast call — bats, for one, holds a test file open
+# until every process a test spawned has exited. Its own stdio is closed off so
+# a caller capturing the command's stdout is not held open by the watchdog.
+# Usage: run_with_deadline <seconds> <command> [args...]
+run_with_deadline() {
+    local secs="$1"
+    shift
+    local pid rc=0
+    "$@" &
+    pid=$!
+    (
+        t="$secs"
+        while (( t-- > 0 )); do
+            sleep 1
+            kill -0 "$pid" 2>/dev/null || exit 0
+        done
+        kill "$pid" 2>/dev/null
+    ) >/dev/null 2>&1 &
+    wait "$pid" || rc=$?
+    return "$rc"
+}

--- a/scripts/lib/display.sh
+++ b/scripts/lib/display.sh
@@ -9,6 +9,8 @@
 # wrapper run as separate processes that inherit the tmux server's PATH and
 # cwd, so a relative path would not survive the hop.
 COUNCIL_DISPLAY_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=deadline.sh
+source "$COUNCIL_DISPLAY_DIR/deadline.sh"
 COUNCIL_RENDER_PL="$COUNCIL_DISPLAY_DIR/render.pl"
 COUNCIL_RENDER_PY="$COUNCIL_DISPLAY_DIR/render.py"
 COUNCIL_PANE_WATCHER="$COUNCIL_DISPLAY_DIR/pane-watcher.sh"
@@ -246,7 +248,7 @@ display_write_perl_renderer() {
 # exit 0, so an import-only probe would silently pick a mangling renderer.
 # Paths are absolute because the pane that runs the result inherits the tmux
 # server's PATH, not this shell's.
-# The uv probe is bounded by a perl alarm (COUNCIL_RICH_PROBE_TIMEOUT, default
+# The uv probe runs under run_with_deadline (COUNCIL_RICH_PROBE_TIMEOUT, default
 # 10s): a cold cache on a dead network otherwise stalls pane opening ~45s
 # before any provider is queried. --no-project keeps uv from resolving — and
 # syncing .venv/uv.lock into — whatever pyproject.toml the cwd contains. The
@@ -262,7 +264,7 @@ council_rich_python() {
         return 0
     fi
     uv=$(command -v uv 2>/dev/null) || uv=""
-    if [[ -n "$uv" ]] && perl -e 'alarm shift; exec @ARGV' "${COUNCIL_RICH_PROBE_TIMEOUT:-10}" \
+    if [[ -n "$uv" ]] && run_with_deadline "${COUNCIL_RICH_PROBE_TIMEOUT:-10}" \
         "$uv" run --quiet --no-project --with rich python3 -c "$probe" 2>/dev/null; then
         printf '%q %s' "$uv" 'run --quiet --no-project --offline --with rich python3'
         return 0

--- a/scripts/lib/jobs.sh
+++ b/scripts/lib/jobs.sh
@@ -55,10 +55,12 @@ job_set() {
     local file tmp
     file=$(job_file "$id")
     tmp=$(mktemp)
-    # The value reaches jq through the environment: MSYS rewrites argv that
-    # looks like a POSIX path (e.g. an outfile "/some/path.md") into a Windows
-    # path before a native jq sees it, so --arg would store the mangled form.
-    k="$key" v="$value" jq '.[env.k] = env.v' "$file" > "$tmp" && mv "$tmp" "$file"
+    # The value reaches jq on stdin: MSYS rewrites a POSIX-looking path (an
+    # outfile "/some/path.md") into a Windows one in argv and in the
+    # environment before a native jq sees it, so --arg and env would both
+    # store the mangled form. The record itself is a path argument, which is
+    # exactly what that rewrite is for.
+    printf '%s' "$value" | jq -Rs --arg k "$key" --slurpfile doc "$file" '$doc[0] + {($k): .}' > "$tmp" && mv "$tmp" "$file"
 }
 
 job_status() {

--- a/scripts/lib/jobs.sh
+++ b/scripts/lib/jobs.sh
@@ -55,7 +55,10 @@ job_set() {
     local file tmp
     file=$(job_file "$id")
     tmp=$(mktemp)
-    jq --arg k "$key" --arg v "$value" '.[$k] = $v' "$file" > "$tmp" && mv "$tmp" "$file"
+    # The value reaches jq through the environment: MSYS rewrites argv that
+    # looks like a POSIX path (e.g. an outfile "/some/path.md") into a Windows
+    # path before a native jq sees it, so --arg would store the mangled form.
+    k="$key" v="$value" jq '.[env.k] = env.v' "$file" > "$tmp" && mv "$tmp" "$file"
 }
 
 job_status() {

--- a/scripts/providers/antigravity.sh
+++ b/scripts/providers/antigravity.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/verbosity.sh"
+source "$SCRIPT_DIR/../lib/deadline.sh"
 
 verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
 
@@ -120,19 +121,18 @@ fi
 # Flags must precede the prompt (see above), so -p goes on last.
 ARGS+=(-p "$PROMPT_ARG")
 
-# Bound the CLI the way API providers are bounded by curl --max-time. GNU
-# `timeout` is absent on stock macOS, so use perl's alarm (perl is already a
-# renderer dependency); the pending alarm survives exec and kills the CLI after
-# COUNCIL_TIMEOUT seconds, surfacing as exit 142 (128 + SIGALRM).
+# Bound the CLI the way API providers are bounded by curl --max-time:
+# run_with_deadline ends it after COUNCIL_TIMEOUT seconds, surfacing as exit
+# 143 (128 + SIGTERM).
 # One attempt, where the API providers retry — see COUNCIL_CLI_TIMEOUT in
 # docs/ARCHITECTURE.md for why the two defaults differ.
 COUNCIL_TIMEOUT="${COUNCIL_TIMEOUT:-${COUNCIL_CLI_TIMEOUT:-1200}}"
 
-if RESPONSE=$(perl -e 'alarm shift; exec @ARGV' "$COUNCIL_TIMEOUT" agy "${ARGS[@]}" 2>"$ERR_TMP"); then
+if RESPONSE=$(run_with_deadline "$COUNCIL_TIMEOUT" agy "${ARGS[@]}" 2>"$ERR_TMP"); then
     echo "$RESPONSE"
 else
     rc=$?
-    if [[ $rc -eq 142 ]]; then
+    if [[ $rc -eq 143 ]]; then
         echo "Error from antigravity CLI: timed out after ${COUNCIL_TIMEOUT}s" >&2
     else
         ERR_MSG=$(tr '\n' ' ' < "$ERR_TMP" | head -c 500)

--- a/scripts/providers/codex.sh
+++ b/scripts/providers/codex.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/verbosity.sh"
+source "$SCRIPT_DIR/../lib/deadline.sh"
 
 verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
 
@@ -45,10 +46,9 @@ ARGS=(exec --skip-git-repo-check -s read-only)
 [[ -n "${CODEX_MODEL:-}" ]] && ARGS+=(-m "$CODEX_MODEL")
 ARGS+=("$FULL_PROMPT")
 
-# Bound the CLI the way API providers are bounded by curl --max-time. GNU
-# `timeout` is absent on stock macOS, so use perl's alarm (perl is already a
-# renderer dependency); the pending alarm survives exec and kills the CLI after
-# COUNCIL_TIMEOUT seconds, surfacing as exit 142 (128 + SIGALRM).
+# Bound the CLI the way API providers are bounded by curl --max-time:
+# run_with_deadline ends it after COUNCIL_TIMEOUT seconds, surfacing as exit
+# 143 (128 + SIGTERM).
 # One attempt, where the API providers retry — see COUNCIL_CLI_TIMEOUT in
 # docs/ARCHITECTURE.md for why the two defaults differ.
 COUNCIL_TIMEOUT="${COUNCIL_TIMEOUT:-${COUNCIL_CLI_TIMEOUT:-1200}}"
@@ -56,11 +56,11 @@ COUNCIL_TIMEOUT="${COUNCIL_TIMEOUT:-${COUNCIL_CLI_TIMEOUT:-1200}}"
 ERR_TMP=$(mktemp)
 trap 'rm -f "$ERR_TMP"' EXIT
 
-if RESPONSE=$(perl -e 'alarm shift; exec @ARGV' "$COUNCIL_TIMEOUT" codex "${ARGS[@]}" 2>"$ERR_TMP"); then
+if RESPONSE=$(run_with_deadline "$COUNCIL_TIMEOUT" codex "${ARGS[@]}" 2>"$ERR_TMP"); then
     echo "$RESPONSE"
 else
     rc=$?
-    if [[ $rc -eq 142 ]]; then
+    if [[ $rc -eq 143 ]]; then
         echo "Error from codex CLI: timed out after ${COUNCIL_TIMEOUT}s" >&2
     else
         ERR_MSG=$(tr '\n' ' ' < "$ERR_TMP" | head -c 500)

--- a/scripts/providers/grok-cli.sh
+++ b/scripts/providers/grok-cli.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/verbosity.sh"
+source "$SCRIPT_DIR/../lib/deadline.sh"
 
 verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
 
@@ -50,10 +51,9 @@ ARGS=(-p "$FULL_PROMPT" --output-format plain --sandbox read-only --no-plan)
 # env auth, so an unset GROK_CLI_MODEL defers to the CLI's own default.
 [[ -n "${GROK_CLI_MODEL:-}" ]] && ARGS+=(-m "$GROK_CLI_MODEL")
 
-# Bound the CLI the way API providers are bounded by curl --max-time. GNU
-# `timeout` is absent on stock macOS, so use perl's alarm (perl is already a
-# renderer dependency); the pending alarm survives exec and kills the CLI after
-# COUNCIL_TIMEOUT seconds, surfacing as exit 142 (128 + SIGALRM).
+# Bound the CLI the way API providers are bounded by curl --max-time:
+# run_with_deadline ends it after COUNCIL_TIMEOUT seconds, surfacing as exit
+# 143 (128 + SIGTERM).
 # One attempt, where the API providers retry — see COUNCIL_CLI_TIMEOUT in
 # docs/ARCHITECTURE.md for why the two defaults differ.
 COUNCIL_TIMEOUT="${COUNCIL_TIMEOUT:-${COUNCIL_CLI_TIMEOUT:-1200}}"
@@ -61,11 +61,11 @@ COUNCIL_TIMEOUT="${COUNCIL_TIMEOUT:-${COUNCIL_CLI_TIMEOUT:-1200}}"
 ERR_TMP=$(mktemp)
 trap 'rm -f "$ERR_TMP"' EXIT
 
-if RESPONSE=$(perl -e 'alarm shift; exec @ARGV' "$COUNCIL_TIMEOUT" grok "${ARGS[@]}" 2>"$ERR_TMP"); then
+if RESPONSE=$(run_with_deadline "$COUNCIL_TIMEOUT" grok "${ARGS[@]}" 2>"$ERR_TMP"); then
     echo "$RESPONSE"
 else
     rc=$?
-    if [[ $rc -eq 142 ]]; then
+    if [[ $rc -eq 143 ]]; then
         echo "Error from grok CLI: timed out after ${COUNCIL_TIMEOUT}s" >&2
     else
         ERR_MSG=$(tr '\n' ' ' < "$ERR_TMP" | head -c 500)

--- a/scripts/providers/kimi-cli.sh
+++ b/scripts/providers/kimi-cli.sh
@@ -6,6 +6,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/../lib/verbosity.sh"
+source "$SCRIPT_DIR/../lib/deadline.sh"
 
 verbosity_prefix VERBOSITY_PREFIX "${COUNCIL_VERBOSITY:-standard}"
 
@@ -55,10 +56,9 @@ ARGS=(-p "$FULL_PROMPT" --output-format stream-json --agent-file "$AGENT_FILE")
 # CLI's own default_model in config.toml (mirrors codex.sh and grok-cli.sh).
 [[ -n "${KIMI_CLI_MODEL:-}" ]] && ARGS+=(-m "$KIMI_CLI_MODEL")
 
-# Bound the CLI the way API providers are bounded by curl --max-time. GNU
-# `timeout` is absent on stock macOS, so use perl's alarm (perl is already a
-# renderer dependency); the pending alarm survives exec and kills the CLI after
-# COUNCIL_TIMEOUT seconds, surfacing as exit 142 (128 + SIGALRM).
+# Bound the CLI the way API providers are bounded by curl --max-time:
+# run_with_deadline ends it after COUNCIL_TIMEOUT seconds, surfacing as exit
+# 143 (128 + SIGTERM).
 # One attempt, where the API providers retry — see COUNCIL_CLI_TIMEOUT in
 # docs/ARCHITECTURE.md for why the two defaults differ.
 COUNCIL_TIMEOUT="${COUNCIL_TIMEOUT:-${COUNCIL_CLI_TIMEOUT:-1200}}"
@@ -67,13 +67,7 @@ ERR_TMP=$(mktemp)
 OUT_TMP=$(mktemp)
 trap 'rm -f "$ERR_TMP" "$OUT_TMP"' EXIT
 
-# Only the reaping shell's own stderr is silenced, not the CLI's: when the
-# alarm kills the child, bash reports the signal itself ("Alarm clock: 14",
-# with the PID and the whole command line) on this script's stderr, and the
-# council stores provider stderr verbatim as the error text — so that report
-# would reach the pane in place of the timeout message below. The child keeps
-# its own redirections, so its output still lands in the temp files.
-{ if perl -e 'alarm shift; exec @ARGV' "$COUNCIL_TIMEOUT" kimi "${ARGS[@]}" >"$OUT_TMP" 2>"$ERR_TMP"; then rc=0; else rc=$?; fi; } 2>/dev/null
+if run_with_deadline "$COUNCIL_TIMEOUT" kimi "${ARGS[@]}" >"$OUT_TMP" 2>"$ERR_TMP"; then rc=0; else rc=$?; fi
 if [[ $rc -eq 0 ]]; then
     # Concatenate every assistant chunk; a long answer may arrive in several.
     # Read line by line (-nR + inputs) rather than slurping: `jq -s` parses the
@@ -102,7 +96,7 @@ if [[ $rc -eq 0 ]]; then
     fi
     echo "$RESPONSE"
 else
-    if [[ $rc -eq 142 ]]; then
+    if [[ $rc -eq 143 ]]; then
         echo "Error from kimi CLI: timed out after ${COUNCIL_TIMEOUT}s" >&2
     else
         ERR_MSG=$(tr '\n' ' ' < "$ERR_TMP" | head -c 500)

--- a/scripts/query-council.sh
+++ b/scripts/query-council.sh
@@ -915,8 +915,10 @@ if [[ "$DEBATE_MODE" == true ]]; then
             else
                 envelope=$(run_provider_with_model_fallback "$provider" "$script" "$debate_prompt") && r2_rc=0 || r2_rc=$?
                 if [[ ${r2_rc:-0} -eq 0 ]]; then
-                    jq -n --argjson e "$envelope" \
-                        '{status: "success", response: $e.response, model: $e.model, model_fallback: $e.model_fallback}' > "$output_file"
+                    # The envelope carries the full rebuttal, which embeds every
+                    # round-1 answer: stdin, never argv — see merge_result for
+                    # the MSYS ARG_MAX rationale.
+                    printf '%s' "$envelope" | jq '{status: "success", response: .response, model: .model, model_fallback: .model_fallback}' > "$output_file"
                 else
                     fb_json=$(attempt_api_fallback "$provider" "$debate_prompt")
                     if [[ -n "$fb_json" ]]; then

--- a/scripts/run-council.sh
+++ b/scripts/run-council.sh
@@ -144,7 +144,9 @@ run_cancel() {
         exit 1
     fi
     local status pid
-    IFS=$'\t' read -r status pid < <(jq -r '[.status, .pid // ""] | @tsv' "$file")
+    # tr strips the \r jq's Windows build appends to piped stdout; read keeps
+    # it on the pid, and pgrep will not take "1234\r" as a parent.
+    IFS=$'\t' read -r status pid < <(jq -r '[.status, .pid // ""] | @tsv' "$file" | tr -d '\r')
     case "$status" in
         queued|running)
             # Mark first so the worker's exit trap sees a terminal status

--- a/scripts/stop-review-gate.sh
+++ b/scripts/stop-review-gate.sh
@@ -16,9 +16,11 @@ EVENT=$(cat)
 # disabled - the gate fails open by design.
 CONFIG=".claude/council-stop-gate.json"
 [[ -f "$CONFIG" ]] || exit 0
+# tr strips the \r jq's Windows build appends to piped stdout: read keeps it
+# on the last field, and "1\r" is not a number max_iterations can compare to.
 ENABLED="" PROVIDER="" MAX_ITER=""
 IFS=$'\t' read -r ENABLED PROVIDER MAX_ITER < <(
-    jq -r '[(.enabled // false), (.provider // "codex"), (.max_iterations // 1)] | @tsv' "$CONFIG" 2>/dev/null
+    jq -r '[(.enabled // false), (.provider // "codex"), (.max_iterations // 1)] | @tsv' "$CONFIG" 2>/dev/null | tr -d '\r'
 ) || true
 [[ "$ENABLED" == "true" ]] || exit 0
 
@@ -33,7 +35,7 @@ esac
 # Guard 1: never re-gate a continuation already triggered by a stop hook
 SESSION_ID=""
 IFS=$'\t' read -r ACTIVE SESSION_ID < <(
-    echo "$EVENT" | jq -r '[(.stop_hook_active // false), (.session_id // "unknown")] | @tsv'
+    echo "$EVENT" | jq -r '[(.stop_hook_active // false), (.session_id // "unknown")] | @tsv' | tr -d '\r'
 ) || true
 [[ "$ACTIVE" == "true" ]] && exit 0
 [[ -n "$SESSION_ID" ]] || SESSION_ID=unknown

--- a/tests/argmax.bats
+++ b/tests/argmax.bats
@@ -130,7 +130,13 @@ PROVIDER
     local r1 r2
     r1=$(echo "$output" | jq -r '.round1.antigravity.response')
     r2=$(echo "$output" | jq -r '.round2.antigravity.response')
+    # Shown on failure: the bytes at each end, so a platform difference in how
+    # the marker arrives is visible rather than inferred.
+    echo "r1 head: $(printf '%s' "$r1" | head -c 24 | od -c | head -2)"
+    echo "r2 head: $(printf '%s' "$r2" | head -c 24 | od -c | head -2)"
+    echo "r2 tail: $(printf '%s' "$r2" | tail -c 24 | od -c | head -2)"
     [ "${#r1}" -ge "$BIG_BYTES" ]
+    [[ "$r1" == "$MARK_START"* ]]
     [[ "$r2" == "$MARK_START"* ]]
     [[ "$r2" == *"$MARK_END" ]]
     [ "${#r2}" -ge "$BIG_BYTES" ]

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -78,14 +78,15 @@ teardown() {
 @test "sha256_hex: falls back to sha256sum when shasum is absent" {
     local fake="${BATS_TEST_TMPDIR}/hashbin" tools="${BATS_TEST_TMPDIR}/tools"
     mkdir -p "$fake" "$tools"
-    # A sha256sum that needs no shasum on PATH (perl is a hard dependency)
-    cat > "$fake/sha256sum" <<'EOF'
-#!/bin/bash
-perl -MDigest::SHA=sha256_hex -0777 -ne 'print sha256_hex($_)."  -\n"'
-EOF
-    chmod +x "$fake/sha256sum"
-    ln -s "$(command -v cut)" "$tools/cut"
-    ln -s "$(command -v perl)" "$tools/perl"
+    # A sha256sum that needs no shasum on PATH (perl is a hard dependency).
+    # Wrapper scripts rather than symlinked binaries: on Git Bash `ln -s`
+    # copies the file, and a copied perl or cut loses the DLLs beside it.
+    local perl_bin cut_bin
+    perl_bin=$(command -v perl); cut_bin=$(command -v cut)
+    printf '#!/bin/bash\nexec %q -MDigest::SHA=sha256_hex -0777 -ne %q\n' \
+        "$perl_bin" 'print sha256_hex($_)."  -\n"' > "$fake/sha256sum"
+    printf '#!/bin/bash\nexec %q "$@"\n' "$cut_bin" > "$tools/cut"
+    chmod +x "$fake/sha256sum" "$tools/cut"
     # PATH (set inside, so the outer bash is still found) has the fake sha256sum
     # but no shasum, forcing the fallback branch
     run bash -c "export PATH='${fake}:${tools}'; source '${LIB_DIR}/hash.sh'; printf abc | sha256_hex"

--- a/tests/deadline.bats
+++ b/tests/deadline.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# ABOUTME: Tests for scripts/lib/deadline.sh
+# ABOUTME: Pins run_with_deadline's passthrough and its kill at the deadline
+
+load test_helper
+
+LIB="${LIB_DIR}/deadline.sh"
+
+setup() {
+    source "$LIB"
+}
+
+# The pane-watcher tests feed keystrokes through a process substitution, so
+# the command under the deadline must read the caller's stdin. A bare `&`
+# gives a background job /dev/null on bash 3.2.
+@test "run_with_deadline: the command reads the caller's stdin" {
+    run run_with_deadline 5 cat < <(printf 'typed'; sleep 0.2)
+    [ "$status" -eq 0 ]
+    [ "$output" = "typed" ]
+}
+
+@test "run_with_deadline: a command that finishes returns its own status" {
+    run run_with_deadline 5 bash -c 'echo done; exit 7'
+    [ "$status" -eq 7 ]
+    [ "$output" = "done" ]
+}
+
+@test "run_with_deadline: a command past the deadline is ended with status 143" {
+    local started
+    started=$(date +%s)
+    run run_with_deadline 1 sleep 20
+    [ "$status" -eq 143 ]
+    # Ended at the deadline, not when sleep would have finished on its own.
+    [ $(( $(date +%s) - started )) -lt 10 ]
+}
+
+# The watchdog leaves as soon as the command is gone. Were it a plain
+# `sleep N; kill`, the `wait` here would take the whole 30 seconds, and bats
+# would hold the test file open just as long after every fast call.
+@test "run_with_deadline: no watchdog outlives a fast command" {
+    local started
+    started=$(date +%s)
+    run bash -c "source '$LIB'; run_with_deadline 30 true; wait"
+    [ "$status" -eq 0 ]
+    [ $(( $(date +%s) - started )) -lt 10 ]
+}

--- a/tests/display.bats
+++ b/tests/display.bats
@@ -244,7 +244,7 @@ FAKE
     [[ "$output" == *"SENTINEL_REACHED"* ]]
 }
 
-@test "display: pane_response_write is atomic — no temp file, complete content" {
+@test "display: pane_response_write is atomic - no temp file, complete content" {
     source "$LIB"
     mkdir -p "$PANE_DIR/responses"
     pane_response_write "$PANE_DIR" gemini "$(printf 'a\nb\nc')"

--- a/tests/format-output.bats
+++ b/tests/format-output.bats
@@ -129,3 +129,20 @@ envelope_with_entry() {
     [ "$status" -eq 0 ]
     [[ "$output" != *"unavailable"* ]]
 }
+
+@test "format-output: the first provider key renders when jq emits CRLF" {
+    # jq's Windows build CRLF-translates its stdout when piped, so the first
+    # `keys[]` entry carries a stray \r and `.round1["gemini\r"]` misses,
+    # rendering the slot as `null`. gemini sorts first, so it took the hit.
+    # On other platforms this passes trivially; the Windows CI job is where
+    # it earns its place.
+    local json
+    json=$(jq -n '{metadata: {quiet_mode: false, debate_mode: false},
+        round1: {gemini: {status: "success", model: "g", response: "GEMINI_ANSWER"},
+                 openai: {status: "success", model: "o", response: "OPENAI_ANSWER"}}}')
+    run bash "$SCRIPT" "$json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"GEMINI_ANSWER"* ]]
+    [[ "$output" == *"OPENAI_ANSWER"* ]]
+    [[ "$output" != *"null"* ]]
+}

--- a/tests/jobs.bats
+++ b/tests/jobs.bats
@@ -166,6 +166,36 @@ wait_for_job() {
     fi
 }
 
+@test "run-council --cancel: kills the worker when jq emits CRLF" {
+    # The status/pid read is a process substitution, where MSYS bash does not
+    # strip the \r jq's Windows build appends. bash 5's kill tolerates a pid
+    # of "1234\r" but pgrep does not, so kill_tree ends the worker and leaves
+    # its whole query tree running until the CLI gives up on its own.
+    command -v pgrep >/dev/null 2>&1 || skip "pgrep not installed"
+    install_crlf_jq
+    export COUNCIL_FAKE_BEHAVIOR=slow
+    export COUNCIL_FAKE_SLEEP=30
+    local id pid children waited=0
+    id=$(bash "$RUN_COUNCIL" --async --providers=codex -- "test question" | head -1)
+    await_any_file "${COUNCIL_JOBS_DIR}/${id}.json"
+    pid=$(jq -r '.pid // empty' "${COUNCIL_JOBS_DIR}/${id}.json")
+    [[ -n "$pid" ]]
+    # The query tree under the worker takes a moment to spawn.
+    while [[ -z "${children:=$(pgrep -P "$pid" || true)}" ]]; do
+        sleep 0.2
+        waited=$((waited + 1))
+        [[ $waited -lt 40 ]]
+    done
+    PATH="$CRLF_BIN:$PATH" run bash "$RUN_COUNCIL" --cancel="$id"
+    [ "$status" -eq 0 ]
+    sleep 1
+    ! kill -0 "$pid" 2>/dev/null
+    local child
+    for child in $children; do
+        ! kill -0 "$child" 2>/dev/null
+    done
+}
+
 @test "run-council: sync mode without flags is unchanged" {
     export COUNCIL_FAKE_BEHAVIOR=valid
     run bash "$RUN_COUNCIL" --providers=codex -- "test question"

--- a/tests/jobs.bats
+++ b/tests/jobs.bats
@@ -74,6 +74,9 @@ wait_for_job() {
     job_write myjob queued
     job_set myjob outfile "/some/path.md"
     run jq -r '.outfile' "${COUNCIL_JOBS_DIR}/myjob.json"
+    # Shown on failure: what was stored, so a platform rewrite of the value
+    # is visible rather than inferred.
+    echo "stored outfile: $output"
     [ "$output" == "/some/path.md" ]
 }
 

--- a/tests/pane-watcher.bats
+++ b/tests/pane-watcher.bats
@@ -7,10 +7,12 @@ bats_require_minimum_version 1.5.0
 
 LIB="${LIB_DIR}/display.sh"
 WATCHER="${LIB_DIR}/pane-watcher.sh"
+DEADLINE="${LIB_DIR}/deadline.sh"
 
 # Build a watch dir the watcher consumes in one pass: a perl render.sh plus
 # .done pre-created, so the poll loop breaks after its first iteration.
 setup() {
+    source "$DEADLINE"
     mkdir -p "$TEST_TMP_DIR"
     W=$(mktemp -d "${TEST_TMP_DIR}/watch.XXXXXX")
     mkdir -p "$W/responses"
@@ -70,12 +72,17 @@ await_renders() {
     done
 }
 
-# The perl alarm turns a regression in the .done exit path into a SIGALRM
-# failure (status 142) instead of a hung bats run.
+# The watcher under run_with_deadline, so a regression in the .done exit path
+# fails with status 143 instead of hanging the bats run. A shell function, not
+# a binary, so callers set COUNCIL_AUTO_CLOSE as a prefix assignment on `run`
+# rather than through env. (A perl alarm never reaches the watcher on Windows.)
+bounded_watcher() {
+    PATH="$FAKE_BIN:$PATH" COUNCIL_NO_TTY_QUERY=1 \
+        run_with_deadline "$1" bash "$WATCHER" "$W" "$LIB"
+}
+
 run_watcher() {
-    run --separate-stderr env COUNCIL_AUTO_CLOSE=1 COUNCIL_NO_TTY_QUERY=1 \
-        PATH="$FAKE_BIN:$PATH" \
-        perl -e 'alarm shift; exec @ARGV' 10 bash "$WATCHER" "$W" "$LIB"
+    COUNCIL_AUTO_CLOSE=1 run --separate-stderr bounded_watcher 10
 }
 
 # Everything the watcher printed after its last screen+scrollback clear, i.e.
@@ -242,9 +249,7 @@ blank_lines_before() {
     # would sit on the old width forever. bash 3.2 rejects a fractional read
     # timeout, so the prompt polls once a second and the settle check needs two
     # of those ticks.
-    run --separate-stderr env COUNCIL_AUTO_CLOSE=0 COUNCIL_NO_TTY_QUERY=1 \
-        PATH="$FAKE_BIN:$PATH" \
-        perl -e 'alarm shift; exec @ARGV' 12 bash "$WATCHER" "$W" "$LIB" \
+    COUNCIL_AUTO_CLOSE=0 run --separate-stderr bounded_watcher 12 \
         < <(await_renders 2; printf '\033')
     [ "$status" -eq 0 ]
     [ "$(count_matches GEMINI "$output")" -eq 2 ]
@@ -254,18 +259,14 @@ blank_lines_before() {
     printf 'Hello\n' > "$W/responses/gemini.md"
     # stdin stays open well past the ctrl-d, so only reading the \004 itself
     # can end the wait.
-    run --separate-stderr env COUNCIL_AUTO_CLOSE=0 COUNCIL_NO_TTY_QUERY=1 \
-        PATH="$FAKE_BIN:$PATH" \
-        perl -e 'alarm shift; exec @ARGV' 3 bash "$WATCHER" "$W" "$LIB" \
+    COUNCIL_AUTO_CLOSE=0 run --separate-stderr bounded_watcher 3 \
         < <(printf '\004'; sleep 6)
     [ "$status" -eq 0 ]
 }
 
 @test "watcher: closes when the pane's stdin is gone rather than polling forever" {
     printf 'Hello\n' > "$W/responses/gemini.md"
-    run --separate-stderr env COUNCIL_AUTO_CLOSE=0 COUNCIL_NO_TTY_QUERY=1 \
-        PATH="$FAKE_BIN:$PATH" \
-        perl -e 'alarm shift; exec @ARGV' 8 bash "$WATCHER" "$W" "$LIB" \
+    COUNCIL_AUTO_CLOSE=0 run --separate-stderr bounded_watcher 8 \
         < /dev/null
     [ "$status" -eq 0 ]
 }
@@ -303,9 +304,7 @@ until_watcher_exits() {
     printf 'kimi-cli\terror\t\t\n' >> "$W/status"
     write_offer 5 kimi-cli
     producer_awaits_retry 8 &
-    run --separate-stderr env COUNCIL_AUTO_CLOSE=1 COUNCIL_NO_TTY_QUERY=1 \
-        PATH="$FAKE_BIN:$PATH" \
-        perl -e 'alarm shift; exec @ARGV' 12 bash "$WATCHER" "$W" "$LIB" \
+    COUNCIL_AUTO_CLOSE=1 run --separate-stderr bounded_watcher 12 \
         < <(sleep 1; printf 'r'; until_watcher_exits)
     [ "$status" -eq 0 ]
     [ -z "$stderr" ]
@@ -319,9 +318,7 @@ until_watcher_exits() {
 @test "watcher: esc at the retry offer closes the pane" {
     rm -f "$W/.done"
     write_offer 5 kimi-cli
-    run --separate-stderr env COUNCIL_AUTO_CLOSE=1 COUNCIL_NO_TTY_QUERY=1 \
-        PATH="$FAKE_BIN:$PATH" \
-        perl -e 'alarm shift; exec @ARGV' 8 bash "$WATCHER" "$W" "$LIB" \
+    COUNCIL_AUTO_CLOSE=1 run --separate-stderr bounded_watcher 8 \
         < <(sleep 1; printf '\033'; until_watcher_exits)
     # .done never arrives, so only the close can end the wait — and the watch
     # dir going away is what tells the producer to carry on without a retry.
@@ -336,9 +333,7 @@ until_watcher_exits() {
     # The producer's one-second deadline passes unanswered: it withdraws the
     # offer and finishes.
     producer_awaits_retry 1 &
-    run --separate-stderr env COUNCIL_AUTO_CLOSE=0 COUNCIL_NO_TTY_QUERY=1 \
-        PATH="$FAKE_BIN:$PATH" \
-        perl -e 'alarm shift; exec @ARGV' 12 bash "$WATCHER" "$W" "$LIB" \
+    COUNCIL_AUTO_CLOSE=0 run --separate-stderr bounded_watcher 12 \
         < <(sleep 4; printf '\033'; until_watcher_exits)
     [ "$status" -eq 0 ]
     [[ "$output" == *"[r] retry failed (kimi-cli)"*"[esc/ctrl-d] close"* ]]
@@ -351,9 +346,7 @@ until_watcher_exits() {
     fake_stty 40
     write_offer 5 gemini openai grok perplexity
     producer_awaits_retry 1 &
-    run --separate-stderr env COUNCIL_AUTO_CLOSE=1 COUNCIL_NO_TTY_QUERY=1 \
-        PATH="$FAKE_BIN:$PATH" \
-        perl -e 'alarm shift; exec @ARGV' 8 bash "$WATCHER" "$W" "$LIB"
+    COUNCIL_AUTO_CLOSE=1 run --separate-stderr bounded_watcher 8
     [ "$status" -eq 0 ]
     # Drawn between DECAWM off/on like the waiting line, so a prompt wider
     # than the pane clips instead of leaving a stale wrapped row every tick.
@@ -376,9 +369,7 @@ until_watcher_exits() {
         printf 'kimi-cli\terror\t\t\n' >> "$W/status"
         touch "$W/.done"
     ) &
-    run --separate-stderr env COUNCIL_AUTO_CLOSE=0 COUNCIL_NO_TTY_QUERY=1 \
-        PATH="$FAKE_BIN:$PATH" \
-        perl -e 'alarm shift; exec @ARGV' 16 bash "$WATCHER" "$W" "$LIB" \
+    COUNCIL_AUTO_CLOSE=0 run --separate-stderr bounded_watcher 16 \
         < <(sleep 1; printf 'r'; sleep 3; echo 100 > "$COLS_FILE"; sleep 4; printf '\033'; until_watcher_exits)
     [ "$status" -eq 0 ]
     [[ "$output" == *$'\033[3J'* ]]

--- a/tests/pane-watcher.bats
+++ b/tests/pane-watcher.bats
@@ -374,6 +374,12 @@ until_watcher_exits() {
     [ "$status" -eq 0 ]
     [[ "$output" == *$'\033[3J'* ]]
     replay=$(after_last_redraw "$output")
+    # Shown on failure: how many redraws happened and what the last one
+    # holds, so a slow runner's ordering is visible rather than inferred.
+    echo "redraws: $(count_matches $'\033\[3J' "$output")"
+    echo "second-failure matches in full output: $(count_matches 'second failure' "$output")"
+    echo "replay (plain text):"
+    plain_text "$replay"
     [ "$(count_matches 'first failure' "$replay")" -eq 1 ]
     [ "$(count_matches 'second failure' "$replay")" -eq 1 ]
     [[ "$replay" == *"first failure"*"second failure"* ]]

--- a/tests/stop-gate.bats
+++ b/tests/stop-gate.bats
@@ -81,6 +81,20 @@ dirty_diff() {
     [[ "$(echo "$output" | jq -r '.reason')" == *"tests are failing"* ]]
 }
 
+@test "stop-gate: verdict survives a jq that emits CRLF" {
+    # jq's Windows build CRLF-translates piped stdout, so the @tsv config read
+    # hands the gate "1\r" as max_iterations and "test-session\r" as the
+    # session id. On other platforms this passes trivially; the Windows CI job
+    # is where it earns its place.
+    install_crlf_jq
+    enable_gate
+    dirty_diff
+    export COUNCIL_FAKE_BEHAVIOR=block-verdict
+    PATH="$CRLF_BIN:$PATH" run bash "$GATE" <<< "$(stop_event)"
+    [ "$status" -eq 0 ]
+    assert_json_eq "$output" '.decision' "block"
+}
+
 @test "stop-gate: allows when reviewer verdict is not BLOCK" {
     enable_gate
     dirty_diff

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -110,6 +110,23 @@ path_without_clis() {
     echo "${clean%:}"
 }
 
+# Helper: put a jq on PATH whose stdout ends every line with \r\n, as jq's
+# Windows build does when piped. Sets CRLF_BIN; prefix PATH="$CRLF_BIN:$PATH"
+# on the one invocation under test so the test's own jq calls stay clean.
+install_crlf_jq() {
+    local real_jq
+    real_jq=$(command -v jq)
+    CRLF_BIN="${BATS_TEST_TMPDIR}/crlf-bin"
+    mkdir -p "$CRLF_BIN"
+    cat > "$CRLF_BIN/jq" <<EOF
+#!/bin/bash
+"$real_jq" "\$@" | sed 's/\$/\r/'
+exit "\${PIPESTATUS[0]}"
+EOF
+    chmod +x "$CRLF_BIN/jq"
+    export CRLF_BIN
+}
+
 # Helper: assert JSON field equals value
 # Usage: assert_json_eq "$json" ".field" "expected"
 assert_json_eq() {

--- a/tests/theme.bats
+++ b/tests/theme.bats
@@ -59,17 +59,17 @@ setup() {
 # an ST-only delimiter). The parse/luminance logic now lives in a pure function
 # so every branch is testable without a terminal.
 
-@test "theme: osc reply — black background maps to dark" {
+@test "theme: osc reply - black background maps to dark" {
     run council_theme_from_osc_reply 'rgb:0000/0000/0000'
     [ "$output" = "dark" ]
 }
 
-@test "theme: osc reply — white background maps to light" {
+@test "theme: osc reply - white background maps to light" {
     run council_theme_from_osc_reply 'rgb:ffff/ffff/ffff'
     [ "$output" = "light" ]
 }
 
-@test "theme: osc reply — luminance threshold sits at 127" {
+@test "theme: osc reply - luminance threshold sits at 127" {
     # 0x80 = 128 on every channel -> lum 128 (> 127) -> light
     run council_theme_from_osc_reply 'rgb:8080/8080/8080'
     [ "$output" = "light" ]
@@ -78,7 +78,7 @@ setup() {
     [ "$output" = "dark" ]
 }
 
-@test "theme: osc reply — handles 8-bit channels and a full OSC frame" {
+@test "theme: osc reply - handles 8-bit channels and a full OSC frame" {
     run council_theme_from_osc_reply 'rgb:ff/ff/ff'
     [ "$output" = "light" ]
     # The tty returns the triplet wrapped in the OSC frame; parsing must find it.
@@ -86,7 +86,7 @@ setup() {
     [ "$output" = "dark" ]
 }
 
-@test "theme: osc reply — unparseable input yields empty (no assertion)" {
+@test "theme: osc reply - unparseable input yields empty (no assertion)" {
     run council_theme_from_osc_reply 'garbage'
     [ -z "$output" ]
     run council_theme_from_osc_reply ''
@@ -167,7 +167,7 @@ render_with_theme() {
     [[ "$output" == *"judge"* ]]
 }
 
-@test "renderer: fenced code block uses ┌/└ markers and copies content verbatim" {
+@test "renderer: fenced code block uses corner markers and copies content verbatim" {
     run render_with_theme dark $'```bash\n# cfg line\n**not bold**\n```'
     [ "$status" -eq 0 ]
     [[ "$output" == *"┌─────"* ]]     # open marker
@@ -180,7 +180,7 @@ render_with_theme() {
     [[ "$output" != *$'\033[1;97m'* ]]    # '**not bold**' is not turned into bold
 }
 
-@test "renderer: H1–H3 get distinct heading styles" {
+@test "renderer: H1-H3 get distinct heading styles" {
     run render_with_theme dark $'# Title One\n## Title Two\n### Title Three'
     [ "$status" -eq 0 ]
     [[ "$output" == *"Title One"* ]]


### PR DESCRIPTION
Adds windows-latest to the bats matrix (Git Bash 5.3, jq via choco, bats via npm). The full suite runs there: 550/550, 23 skips, all of them the gated E2E / no-CLI / no-Rich ones (run 33372345518, ~22 min).

Windows exposed runtime bugs, not just test artifacts:

- `perl -e 'alarm shift; exec @ARGV'` never bounded a CLI on Windows (perl emulates exec by spawn-and-wait; the alarm ends perl, the CLI lives on). Replaced by `scripts/lib/deadline.sh` `run_with_deadline` for the CLI providers, the uv probe and the pane-watcher tests; timeout status is 143.
- `--debate` lost round 2: the rebuttal envelope went to jq on argv, past MSYS's ~32 KB ARG_MAX. Now stdin, like `merge_result`.
- jq's Windows build CRLF-terminates piped stdout, and MSYS bash keeps the `\r` on a `read < <(...)`: the stop gate read `max_iterations` as `1\r`, `run_cancel` read the pid as `1234\r`. Both strip it; a CRLF-emitting jq wrapper in `test_helper.bash` reproduces it on any platform.
- MSYS rewrites POSIX-looking paths in argv *and* environment values before a native jq sees them; `job_set` hands its value over on stdin.
- bats on MSYS cannot find a test whose name has a non-ASCII character; eight names are ASCII now.

Known: `watcher: a provider that fails again on retry replays both errors, each once` failed once on Windows (run 3) and passed on runs 2 and 4 with no change to the code under test — a timing flake on the slow runner. The test now prints its redraw count and replay on failure so the next occurrence carries evidence.

https://claude.ai/code/session_016F2RDvNXJzvk2Wer1BHjGd
