### PR TITLE
ci: read-only token, pinned checkout, security policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   bats:
     name: bats (${{ matrix.os }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install dependencies (Linux)
         if: runner.os == 'Linux'
@@ -58,7 +58,7 @@ jobs:
     name: shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # A linter ships new checks in every release, so an unpinned one reddens
       # main on a commit nobody touched. This job blocks a merge, so it is pinned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to claude-council are documented here. The format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres
 to a `YYYY.M.BUILD` versioning scheme where `BUILD` resets each month.
 
+## Unreleased
+
+### Security
+- `SECURITY.md` points vulnerability reports at GitHub's private advisory form, which is now enabled on the repo.
+- The tests workflow declares `permissions: contents: read`, and its two `actions/checkout` steps are pinned to the v4.2.2 commit. Dependabot watches the actions ecosystem weekly and bumps the pins.
+
 ## 2026.9.8
 
 ### Fixes

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security
+
+Report a vulnerability privately through [GitHub's advisory form](https://github.com/hex/claude-council/security/advisories/new). Don't open a public issue for it.
+
+Fixes land in the latest release only. Expect a reply within a week.


### PR DESCRIPTION
Came out of the awesome-ai-plugins listing scan (score 70, now 89 on a clean export).

- tests workflow gets `permissions: contents: read`
- both `actions/checkout` steps pinned to the v4.2.2 commit, dependabot bumps them weekly
- SECURITY.md pointing at the private advisory form, which I enabled on the repo

What's left in the scan is their secret detector matching `API_KEY="${VAR}"` in the provider scripts. That's a bug on their side, not ours.
