### PR TITLE
ci(tests): split the Windows bats job into four shards

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,14 +10,27 @@ permissions:
 
 jobs:
   bats:
-    name: bats (${{ matrix.os }})
+    name: bats (${{ matrix.os }}${{ matrix.shard && format(' shard {0}', matrix.shard) || '' }})
     strategy:
       fail-fast: false
+      # Windows spends about a second per test on process creation alone, so
+      # the whole suite there takes ten times its Linux wall time. The lists in
+      # tests/shards/ split it across four runners; tests/shards.bats keeps the
+      # lists complete.
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: ubuntu-latest
+          - os: macos-latest
+          - os: windows-latest
+            shard: 1
+          - os: windows-latest
+            shard: 2
+          - os: windows-latest
+            shard: 3
+          - os: windows-latest
+            shard: 4
     runs-on: ${{ matrix.os }}
-    # Windows spawns processes slowly enough that the suite takes many times its
-    # Linux wall time; the cap turns a hung run into a failure, not a six-hour job.
+    # The cap turns a hung run into a failure, not a six-hour job.
     timeout-minutes: 60
     # Git Bash on the Windows runner, so every step below runs the same shell
     # the plugin runs under there.
@@ -52,7 +65,13 @@ jobs:
       - name: Run bats suite
         env:
           BATS_TEST_TIMEOUT: 120
-        run: bash tests/run_tests.sh
+          SHARD: ${{ matrix.shard }}
+        run: |
+          if [[ -n "$SHARD" ]]; then
+            bash tests/run_tests.sh "$(sed 's|^|tests/|' "tests/shards/$SHARD.txt" | xargs)"
+          else
+            bash tests/run_tests.sh
+          fi
 
   shellcheck:
     name: shellcheck

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ to a `YYYY.M.BUILD` versioning scheme where `BUILD` resets each month.
 - `SECURITY.md` points vulnerability reports at GitHub's private advisory form, which is now enabled on the repo.
 - The tests workflow declares `permissions: contents: read`, and its two `actions/checkout` steps are pinned to the v4.2.2 commit. Dependabot watches the actions ecosystem weekly and bumps the pins.
 
+### CI
+- The Windows bats job runs as four shards listed under `tests/shards/`, about 8 minutes instead of 25. Every test spends about a second in process creation there, so no single file was the cost. `tests/shards.bats` fails when a bats file is missing from the lists.
+
 ## 2026.9.8
 
 ### Fixes

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -488,7 +488,7 @@ claude-council/
 │   └── plugin.json              # Plugin manifest
 ├── .github/
 │   └── workflows/
-│       └── tests.yml            # bats on ubuntu, macos and windows; shellcheck blocks a merge
+│       └── tests.yml            # bats on ubuntu, macos and 4 windows shards; shellcheck blocks a merge
 ├── agents/
 │   └── council-advisor.md       # Proactive suggestions
 ├── commands/
@@ -566,6 +566,7 @@ claude-council/
 │       └── api-patterns.md      # API integration patterns
 ├── tests/
 │   ├── run_tests.sh             # Test runner
+│   ├── shards/                  # Which bats files each Windows CI shard runs
 │   ├── test_helper.bash         # Shared test utilities
 │   ├── fixtures/
 │   │   ├── fake-clis.bash       # Fake codex/agy/grok/kimi/ollama binaries on PATH

--- a/tests/shards.bats
+++ b/tests/shards.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+# The Windows CI job splits the suite across shards listed in tests/shards/.
+# A bats file missing from every list would silently stop running on Windows.
+
+setup() {
+    TESTS_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")" && pwd)"
+    SHARDS_DIR="$TESTS_DIR/shards"
+}
+
+@test "shards: every bats file is listed exactly once across the shard lists" {
+    expected="$(cd "$TESTS_DIR" && ls ./*.bats | sed 's|^\./||' | sort)"
+    listed="$(cat "$SHARDS_DIR"/*.txt | sort)"
+    [ "$listed" = "$expected" ]
+}
+
+@test "shards: every listed file exists" {
+    [ -d "$SHARDS_DIR" ]
+    while read -r f; do
+        [ -f "$TESTS_DIR/$f" ] || { echo "missing: $f"; return 1; }
+    done < <(cat "$SHARDS_DIR"/*.txt)
+}
+
+@test "shards: no shard list is empty" {
+    for list in "$SHARDS_DIR"/*.txt; do
+        [ -s "$list" ] || { echo "empty: $list"; return 1; }
+    done
+}

--- a/tests/shards/.gitattributes
+++ b/tests/shards/.gitattributes
@@ -1,0 +1,1 @@
+*.txt text eol=lf

--- a/tests/shards/1.txt
+++ b/tests/shards/1.txt
@@ -1,0 +1,7 @@
+agent-analysis.bats
+format-output.bats
+providers.bats
+retry.bats
+roles.bats
+shards.bats
+tokens.bats

--- a/tests/shards/2.txt
+++ b/tests/shards/2.txt
@@ -1,0 +1,8 @@
+check-status-probe.bats
+export.bats
+fake-clis.bats
+image.bats
+keys.bats
+release.bats
+theme.bats
+transcript-digest.bats

--- a/tests/shards/3.txt
+++ b/tests/shards/3.txt
@@ -1,0 +1,6 @@
+argmax.bats
+jobs.bats
+pane-watcher.bats
+query-council.bats
+router-seats.bats
+stop-gate.bats

--- a/tests/shards/4.txt
+++ b/tests/shards/4.txt
@@ -1,0 +1,9 @@
+cache.bats
+check-status.bats
+cli-providers.bats
+deadline.bats
+display.bats
+model_fallback.bats
+prompts.bats
+session-transcript.bats
+verbosity.bats


### PR DESCRIPTION
Windows bats took 24 to 30 min against 2.5 on ubuntu. Measured from the run log: 668 tests, median 1.1 s each, floor 0.2 s, flat distribution, biggest file 12%. Process creation per test, so no single file to fix.

- windows runs as 4 shards from `tests/shards/*.txt`, balanced on the measured durations, ~5 min of tests each
- `tests/shards.bats` fails when a bats file is missing from the lists or listed twice
- ubuntu and macos unchanged

Full suite green locally (684).
